### PR TITLE
Implement WaniKani integration, Anki export, and Settings page (issues #9, #10)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -139,6 +139,89 @@ async function startServer() {
     }
   });
 
+  const WK_HEADERS = (token: string) => ({
+    'Authorization': `Bearer ${token}`,
+    'Wanikani-Revision': '20170710',
+    'Content-Type': 'application/json',
+  });
+
+  app.post("/api/wanikani/validate", async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token || typeof token !== 'string') {
+        return res.status(400).json({ valid: false, error: 'No token provided' });
+      }
+      const r = await fetch('https://api.wanikani.com/v2/user', { headers: WK_HEADERS(token) });
+      if (!r.ok) return res.json({ valid: false });
+      const data = await r.json() as { data: { username: string; level: number } };
+      res.json({ valid: true, username: data.data.username, level: data.data.level });
+    } catch (e: any) {
+      console.error('[WaniKani] validate error:', e.message);
+      res.status(500).json({ valid: false, error: e.message });
+    }
+  });
+
+  app.post("/api/wanikani/sync", async (req, res) => {
+    const start = Date.now();
+    try {
+      const { token } = req.body;
+      if (!token || typeof token !== 'string') {
+        return res.status(400).json({ error: 'No token provided' });
+      }
+
+      // Fetch all started kanji assignments (paginated)
+      const assignments = new Map<number, number>(); // subject_id -> srs_stage
+      let assignmentsUrl: string | null = 'https://api.wanikani.com/v2/assignments?subject_types=kanji&started=true';
+      while (assignmentsUrl) {
+        const r = await fetch(assignmentsUrl, { headers: WK_HEADERS(token) });
+        if (!r.ok) return res.status(401).json({ error: 'WaniKani API error' });
+        const body = await r.json() as {
+          data: Array<{ data: { subject_id: number; srs_stage: number } }>;
+          pages: { next_url: string | null };
+        };
+        for (const item of body.data) {
+          assignments.set(item.data.subject_id, item.data.srs_stage);
+        }
+        assignmentsUrl = body.pages?.next_url ?? null;
+      }
+
+      console.log(`[WaniKani] Fetched ${assignments.size} kanji assignments in ${Date.now() - start}ms`);
+
+      // Fetch subjects for those IDs to get characters (batch by 500)
+      const subjectIds = Array.from(assignments.keys());
+      const characters = new Map<number, string>(); // id -> kanji character
+      for (let i = 0; i < subjectIds.length; i += 500) {
+        const batch = subjectIds.slice(i, i + 500).join(',');
+        let subjectsUrl: string | null = `https://api.wanikani.com/v2/subjects?ids=${batch}`;
+        while (subjectsUrl) {
+          const r = await fetch(subjectsUrl, { headers: WK_HEADERS(token) });
+          if (!r.ok) break;
+          const body = await r.json() as {
+            data: Array<{ id: number; data: { characters: string } }>;
+            pages: { next_url: string | null };
+          };
+          for (const item of body.data) {
+            if (item.data.characters) characters.set(item.id, item.data.characters);
+          }
+          subjectsUrl = body.pages?.next_url ?? null;
+        }
+      }
+
+      // Build character -> srs_stage map
+      const result: Record<string, number> = {};
+      for (const [subjectId, srsStage] of assignments) {
+        const char = characters.get(subjectId);
+        if (char) result[char] = srsStage;
+      }
+
+      console.log(`[WaniKani] Sync complete: ${Object.keys(result).length} kanji mapped in ${Date.now() - start}ms`);
+      res.json({ data: result, kanjiCount: Object.keys(result).length });
+    } catch (e: any) {
+      console.error('[WaniKani] sync error:', e.message);
+      res.status(500).json({ error: e.message });
+    }
+  });
+
   if (process.env.NODE_ENV !== "production") {
     const vite = await createViteServer({
       server: { middlewareMode: true },

--- a/server.ts
+++ b/server.ts
@@ -37,12 +37,18 @@ function processText(text: string) {
   const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
   const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
 
+  // Count how many times each base form appears (for frequencyInContent)
+  const baseFormCounts = new Map<string, number>();
   const validWords = new Set<string>();
+
   for (const token of tokens) {
     if (token.surface_form.trim() === '' || isPunctuation(token.surface_form) || isSingleKana(token.surface_form)) continue;
 
     const word = token.basic_form && token.basic_form !== '*' ? token.basic_form : token.surface_form;
-    if (!isSingleKana(word)) validWords.add(word);
+    if (!isSingleKana(word)) {
+      validWords.add(word);
+      baseFormCounts.set(word, (baseFormCounts.get(word) ?? 0) + 1);
+    }
   }
 
   const results = [];
@@ -61,7 +67,8 @@ function processText(text: string) {
     }
 
     const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
-    results.push({ word: wordStr, reading, meaning, jlpt, joyo, score, breakdown });
+    const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
+    results.push({ word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent });
   }
 
   return results;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useMemo } from 'react';
-import { BookOpen, Video, Music, CheckCircle, ChevronRight, PlayCircle, Loader2, Library, Plus } from 'lucide-react';
+import { BookOpen, Video, Music, CheckCircle, ChevronRight, PlayCircle, Loader2, Library, Plus, Settings } from 'lucide-react';
 import { INITIAL_CONTENT, GENERATED_CONTENT, Content } from './data/content';
 import { useContentData } from './hooks/useContentData';
 import { ContentDetail } from './components/ContentDetail';
 import { ImportModal } from './components/ImportModal';
 import { WordDetailModal } from './components/WordDetailModal';
+import { SettingsPage } from './components/SettingsPage';
 import { WordInfo } from './types';
 
 export default function App() {
@@ -18,7 +19,8 @@ export default function App() {
     clearKnownWords,
     clearContentVocab,
     updateWord,
-    setContentVocab
+    setContentVocab,
+    refreshWaniKaniData,
   } = useContentData();
 
   const [customContent, setCustomContent] = useState<Content[]>(() => {
@@ -33,7 +35,7 @@ export default function App() {
   });
   const [selectedContent, setSelectedContent] = useState<Content | null>(null);
   const [displayCount, setDisplayCount] = useState(12);
-  const [view, setView] = useState<'home' | 'vocab' | 'scoring'>('home');
+  const [view, setView] = useState<'home' | 'vocab' | 'scoring' | 'settings'>('home');
   const [showImportOpts, setShowImportOpts] = useState(false);
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [editingWord, setEditingWord] = useState<WordInfo | null>(null);
@@ -65,12 +67,13 @@ export default function App() {
 
   if (selectedContent) {
     return (
-      <ContentDetail 
-        content={selectedContent} 
+      <ContentDetail
+        content={selectedContent}
         onBack={() => setSelectedContent(null)}
         status={getContentStatus(selectedContent.id)}
         loading={loadingContent[selectedContent.id]}
         markWordsAsKnown={markWordsAsKnown}
+        knownWordSet={knownWords}
         onForceReload={() => loadVocabForContent(selectedContent, true)}
         onUpdateContent={(updatedContent) => {
           let updatedVocab = false;
@@ -147,11 +150,17 @@ export default function App() {
             >
               My Vocab
             </button>
-            <button 
+            <button
               onClick={() => setView('scoring')}
               className={`text-sm font-medium transition-colors ${view === 'scoring' ? 'text-indigo-600' : 'text-gray-500 hover:text-gray-900'}`}
             >
               Scoring Guide
+            </button>
+            <button
+              onClick={() => setView('settings')}
+              className={`text-sm font-medium transition-colors flex items-center gap-1 ${view === 'settings' ? 'text-indigo-600' : 'text-gray-500 hover:text-gray-900'}`}
+            >
+              <Settings className="w-4 h-4" /> Settings
             </button>
             <div className="hidden sm:flex items-center gap-2 bg-gray-50 px-3 py-1.5 rounded-full border border-gray-100">
               <CheckCircle className="w-4 h-4 text-green-600" />
@@ -181,6 +190,10 @@ export default function App() {
       )}
 
       <main className="max-w-5xl mx-auto p-6 space-y-8">
+        {view === 'settings' && (
+          <SettingsPage onWaniKaniSync={refreshWaniKaniData} />
+        )}
+
         {view === 'home' && (
           <section>
             <div className="mb-4 flex items-baseline justify-between">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { BookOpen, Video, Music, CheckCircle, ChevronRight, PlayCircle, Loader2, Library, Plus, Settings } from 'lucide-react';
+import { BookOpen, Video, Music, CheckCircle, ChevronRight, PlayCircle, Loader2, Library, Plus, Settings, Search, X } from 'lucide-react';
 import { INITIAL_CONTENT, GENERATED_CONTENT, Content } from './data/content';
 import { useContentData } from './hooks/useContentData';
 import { ContentDetail } from './components/ContentDetail';
@@ -40,6 +40,11 @@ export default function App() {
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [editingWord, setEditingWord] = useState<WordInfo | null>(null);
 
+  // Filter state for home view (#12, #13)
+  const [searchQuery, setSearchQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
+  const [comprehensionFilter, setComprehensionFilter] = useState<'all' | 'almost' | 'ready'>('all');
+
   const ALL_CONTENT = useMemo(() => {
     const map = new Map<string, Content>();
     for (const c of INITIAL_CONTENT) map.set(c.id, c);
@@ -51,19 +56,46 @@ export default function App() {
     localStorage.setItem('customContent', JSON.stringify(customContent));
   }, [customContent]);
 
-  // Sort content by difficulty score
-  const sortedContent = [...ALL_CONTENT].sort((a, b) => {
-    const statusA = getContentStatus(a.id);
-    const statusB = getContentStatus(b.id);
-    
-    // If not loaded, put to end
-    if (statusA.totalCount === 0 && statusB.totalCount !== 0) return 1;
-    if (statusA.totalCount !== 0 && statusB.totalCount === 0) return -1;
-    
-    return statusA.score - statusB.score;
-  });
+  // Sort and filter content (#11, #12, #13)
+  const sortedContent = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return [...ALL_CONTENT]
+      .filter(c => {
+        if (q && !c.title.toLowerCase().includes(q)) return false;
+        if (typeFilter.size > 0 && !typeFilter.has(c.type)) return false;
+        const status = getContentStatus(c.id);
+        if (status.totalCount === 0) return comprehensionFilter === 'all'; // unloaded items only show in 'all'
+        if (comprehensionFilter === 'almost') return status.comprehension >= 90 && status.comprehension < 100;
+        if (comprehensionFilter === 'ready') return status.comprehension === 100;
+        return true;
+      })
+      .sort((a, b) => {
+        const statusA = getContentStatus(a.id);
+        const statusB = getContentStatus(b.id);
+        if (statusA.totalCount === 0 && statusB.totalCount !== 0) return 1;
+        if (statusA.totalCount !== 0 && statusB.totalCount === 0) return -1;
+        return statusA.score - statusB.score;
+      });
+  }, [ALL_CONTENT, searchQuery, typeFilter, comprehensionFilter, getContentStatus]);
 
   const visibleContent = sortedContent.slice(0, displayCount);
+
+  const toggleTypeFilter = (type: string) => {
+    setTypeFilter(prev => {
+      const next = new Set(prev);
+      next.has(type) ? next.delete(type) : next.add(type);
+      return next;
+    });
+    setDisplayCount(12);
+  };
+
+  const hasActiveFilters = searchQuery.trim() !== '' || typeFilter.size > 0 || comprehensionFilter !== 'all';
+
+  const comprehensionColor = (pct: number) => {
+    if (pct >= 90) return 'text-green-700 bg-green-50 border-green-200';
+    if (pct >= 70) return 'text-yellow-700 bg-yellow-50 border-yellow-200';
+    return 'text-red-700 bg-red-50 border-red-200';
+  };
 
   if (selectedContent) {
     return (
@@ -196,9 +228,78 @@ export default function App() {
 
         {view === 'home' && (
           <section>
-            <div className="mb-4 flex items-baseline justify-between">
+            <div className="mb-6 flex items-baseline justify-between">
               <h2 className="text-2xl font-semibold tracking-tight">Recommended For You</h2>
               <p className="text-sm text-gray-500 uppercase tracking-widest font-medium">Sorted by difficulty</p>
+            </div>
+
+            {/* Search + filters (#12, #13) */}
+            <div className="mb-6 space-y-3">
+              <div className="flex flex-wrap gap-2 items-center">
+                {/* Search */}
+                <div className="relative flex-1 min-w-[180px] max-w-xs">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                  <input
+                    type="text"
+                    placeholder="Search by title..."
+                    value={searchQuery}
+                    onChange={e => { setSearchQuery(e.target.value); setDisplayCount(12); }}
+                    className="w-full pl-9 pr-3 py-2 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                  />
+                </div>
+
+                {/* Type filter */}
+                {(['story', 'video', 'music'] as const).map(type => (
+                  <button
+                    key={type}
+                    onClick={() => toggleTypeFilter(type)}
+                    className={`flex items-center gap-1.5 px-3 py-2 text-xs font-semibold uppercase tracking-wider rounded-xl border transition-colors ${
+                      typeFilter.has(type)
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                    }`}
+                  >
+                    {type === 'story' && <BookOpen className="w-3.5 h-3.5" />}
+                    {type === 'video' && <Video className="w-3.5 h-3.5" />}
+                    {type === 'music' && <Music className="w-3.5 h-3.5" />}
+                    {type}
+                  </button>
+                ))}
+
+                {/* Comprehension filter (#13) */}
+                <div className="flex rounded-xl border border-gray-200 overflow-hidden bg-white text-xs font-semibold">
+                  {(['all', 'almost', 'ready'] as const).map((f, i) => (
+                    <button
+                      key={f}
+                      onClick={() => { setComprehensionFilter(f); setDisplayCount(12); }}
+                      className={`px-3 py-2 transition-colors ${i > 0 ? 'border-l border-gray-200' : ''} ${
+                        comprehensionFilter === f
+                          ? 'bg-indigo-600 text-white'
+                          : 'text-gray-600 hover:bg-gray-50'
+                      }`}
+                    >
+                      {f === 'all' ? 'All' : f === 'almost' ? 'Almost There ≥90%' : 'Ready ✓'}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Clear filters */}
+                {hasActiveFilters && (
+                  <button
+                    onClick={() => { setSearchQuery(''); setTypeFilter(new Set()); setComprehensionFilter('all'); setDisplayCount(12); }}
+                    className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700 transition-colors px-2 py-2"
+                  >
+                    <X className="w-3.5 h-3.5" /> Clear
+                  </button>
+                )}
+              </div>
+
+              {/* "Almost There" explanation banner (#13) */}
+              {comprehensionFilter === 'almost' && (
+                <div className="bg-green-50 border border-green-100 rounded-2xl px-4 py-3 text-sm text-green-800">
+                  <strong>i+1 sweet spot</strong> — content where you know ≥90% of words. Challenging enough to encounter new vocabulary, easy enough to enjoy reading.
+                </div>
+              )}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -228,12 +329,30 @@ export default function App() {
                         {content.type === 'music' && <Music className="w-3.5 h-3.5 text-indigo-600" />}
                         <span className="text-xs font-semibold uppercase tracking-wider text-gray-800">{content.type}</span>
                       </div>
+                      {/* Comprehension badge (#11) */}
+                      {!isLoading && status.totalCount > 0 && (
+                        <div className={`absolute top-4 right-4 px-2.5 py-1 rounded-full text-xs font-bold border ${comprehensionColor(status.comprehension)}`}>
+                          {status.comprehension === 100 ? '✓ Ready' : `${status.comprehension}% known`}
+                        </div>
+                      )}
                     </div>
-                    
+
                     <div className="p-5 flex flex-col flex-grow">
                       <h3 className="font-semibold text-lg mb-2">{content.title}</h3>
                       <p className="text-sm text-gray-500 line-clamp-2 mb-4 flex-grow">{content.description}</p>
-                      
+
+                      {/* In "Almost There" mode, show unknown word chips (#13) */}
+                      {comprehensionFilter === 'almost' && !isLoading && status.unknownCount > 0 && (
+                        <div className="flex flex-wrap gap-1 mb-3">
+                          {status.unknownWords.slice(0, 6).map(w => (
+                            <span key={w.word} className="px-2 py-0.5 bg-amber-50 border border-amber-200 text-amber-800 rounded-md text-xs font-medium">{w.word}</span>
+                          ))}
+                          {status.unknownCount > 6 && (
+                            <span className="px-2 py-0.5 text-gray-400 text-xs">+{status.unknownCount - 6} more</span>
+                          )}
+                        </div>
+                      )}
+
                       {isLoading ? (
                         <div className="flex items-center gap-2 text-sm text-gray-400">
                           <Loader2 className="w-4 h-4 animate-spin" />
@@ -258,11 +377,18 @@ export default function App() {
                   </div>
                 );
               })}
+
+              {visibleContent.length === 0 && (
+                <div className="col-span-3 py-16 text-center text-gray-400">
+                  <p className="text-lg font-medium">No content matches your filters.</p>
+                  <button onClick={() => { setSearchQuery(''); setTypeFilter(new Set()); setComprehensionFilter('all'); }} className="mt-3 text-sm text-indigo-500 hover:text-indigo-700 underline">Clear filters</button>
+                </div>
+              )}
             </div>
-            
+
             {displayCount < sortedContent.length && (
               <div className="mt-8 flex justify-center">
-                <button 
+                <button
                   onClick={() => setDisplayCount(prev => prev + 12)}
                   className="bg-white border border-gray-200 text-gray-700 px-6 py-3 rounded-full font-medium hover:bg-gray-50 shadow-sm transition-all"
                 >

--- a/src/components/AnkiExportModal.tsx
+++ b/src/components/AnkiExportModal.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { X, Download, Check } from 'lucide-react';
+import { WordInfo } from '../types';
+import { generateAnkiExport, downloadAnkiFile, AnkiExportOptions } from '../lib/anki';
+
+const JLPT_LEVELS = [
+  { value: 5, label: 'N5' },
+  { value: 4, label: 'N4' },
+  { value: 3, label: 'N3' },
+  { value: 2, label: 'N2' },
+  { value: 1, label: 'N1' },
+  { value: 0, label: 'Native' },
+];
+
+export function AnkiExportModal({
+  contentTitle,
+  words,
+  knownWordSet,
+  onClose,
+}: {
+  contentTitle: string;
+  words: WordInfo[];
+  knownWordSet: Set<string>;
+  onClose: () => void;
+}) {
+  const [deckName, setDeckName] = useState(contentTitle);
+  const [includeKnown, setIncludeKnown] = useState(false);
+  const [jlptFilter, setJlptFilter] = useState<number[]>([]);
+  const [exported, setExported] = useState(false);
+
+  const toggleJlpt = (level: number) => {
+    setJlptFilter(prev =>
+      prev.includes(level) ? prev.filter(l => l !== level) : [...prev, level]
+    );
+  };
+
+  const preview = (() => {
+    let filtered = words;
+    if (!includeKnown) filtered = filtered.filter(w => !knownWordSet.has(w.word));
+    if (jlptFilter.length > 0) filtered = filtered.filter(w => jlptFilter.includes(w.jlpt));
+    const seen = new Set<string>();
+    return filtered.filter(w => { if (seen.has(w.word)) return false; seen.add(w.word); return true; });
+  })();
+
+  const handleExport = () => {
+    const options: AnkiExportOptions = {
+      deckName: deckName.trim() || contentTitle,
+      includeKnown,
+      jlptFilter,
+    };
+    const content = generateAnkiExport(words, knownWordSet, options);
+    const safeName = (deckName.trim() || contentTitle).replace(/[^a-zA-Z0-9_\-　-鿿]/g, '_');
+    downloadAnkiFile(content, `anki-${safeName}.txt`);
+    setExported(true);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl shadow-2xl w-full max-w-lg overflow-hidden">
+        <div className="px-6 py-5 border-b border-gray-100 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Export to Anki</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">Deck Name</label>
+            <input
+              type="text"
+              value={deckName}
+              onChange={e => setDeckName(e.target.value)}
+              className="w-full px-3 py-2 rounded-xl border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+              placeholder="Deck name..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Filter by JLPT Level</label>
+            <p className="text-xs text-gray-400 mb-2">Leave unchecked to include all levels.</p>
+            <div className="flex flex-wrap gap-2">
+              {JLPT_LEVELS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => toggleJlpt(value)}
+                  className={`px-3 py-1.5 text-xs font-semibold rounded-lg border transition-colors ${
+                    jlptFilter.includes(value)
+                      ? 'bg-purple-600 text-white border-purple-600'
+                      : 'bg-gray-50 text-gray-600 border-gray-200 hover:border-purple-300'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setIncludeKnown(v => !v)}
+              className={`w-10 h-6 rounded-full transition-colors relative ${includeKnown ? 'bg-purple-600' : 'bg-gray-200'}`}
+            >
+              <span className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${includeKnown ? 'translate-x-4' : 'translate-x-0.5'}`} />
+            </button>
+            <span className="text-sm text-gray-700">Include known words</span>
+          </div>
+
+          <div className="bg-purple-50 border border-purple-100 rounded-xl px-4 py-3 text-sm text-purple-800">
+            <strong>{preview.length}</strong> words will be exported.
+          </div>
+
+          <div className="bg-amber-50 border border-amber-100 rounded-xl px-4 py-3 text-xs text-amber-800 space-y-1">
+            <p className="font-semibold">How to import into Anki:</p>
+            <ol className="list-decimal list-inside space-y-0.5">
+              <li>Open Anki → File → Import</li>
+              <li>Select the downloaded <code className="bg-amber-100 px-1 rounded">.txt</code> file</li>
+              <li>Confirm the deck name and field mapping, then click Import</li>
+            </ol>
+          </div>
+        </div>
+
+        <div className="px-6 py-5 border-t border-gray-100 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={preview.length === 0}
+            className="px-5 py-2 bg-purple-600 text-white text-sm font-medium rounded-xl hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+          >
+            {exported ? (
+              <><Check className="w-4 h-4" /> Downloaded!</>
+            ) : (
+              <><Download className="w-4 h-4" /> Download Deck</>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ContentDetail.tsx
+++ b/src/components/ContentDetail.tsx
@@ -14,6 +14,7 @@ interface Status {
   score: number;
   unknownWords: WordInfo[];
   knownWords: WordInfo[];
+  comprehension: number;
 }
 
 export function ContentDetail({
@@ -201,10 +202,19 @@ export function ContentDetail({
                   There are <strong className="text-indigo-600">{status.unknownCount}</strong> words you haven't learned yet. We recommend doing a quick lesson before jumping in.
                 </p>
                 <div className="grid grid-cols-1 gap-4">
-                  {(showAllWords ? status.unknownWords : status.unknownWords.slice(0, 10)).map((w, i) => (
+                  {/* Sort by frequency in content descending (#14) */}
+                  {(showAllWords
+                    ? [...status.unknownWords].sort((a, b) => (b.frequencyInContent ?? 0) - (a.frequencyInContent ?? 0))
+                    : [...status.unknownWords].sort((a, b) => (b.frequencyInContent ?? 0) - (a.frequencyInContent ?? 0)).slice(0, 10)
+                  ).map((w, i) => (
                     <div key={i} className="border border-gray-100 bg-gray-50 rounded-xl p-4 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
                       <div>
-                        <div className="text-xs text-gray-500">{w.reading}</div>
+                        <div className="text-xs text-gray-500 flex items-center gap-2">
+                          <span>{w.reading}</span>
+                          {w.frequencyInContent && w.frequencyInContent > 1 && (
+                            <span className="bg-indigo-100 text-indigo-700 font-semibold px-1.5 py-0.5 rounded text-[10px]">×{w.frequencyInContent}</span>
+                          )}
+                        </div>
                         <div className="font-bold text-lg">{w.word}</div>
                         <div className="text-sm font-medium text-gray-700 mt-1">{w.meaning}</div>
                       </div>
@@ -329,6 +339,23 @@ export function ContentDetail({
           <div className="bg-[#F9F8F6] p-6 rounded-3xl border border-[#EBE8E0]">
              <h3 className="font-semibold text-sm uppercase tracking-wider text-gray-500 mb-4">Content Stats</h3>
              <ul className="space-y-3">
+               {/* Comprehension % (#11) */}
+               {!loading && status.totalCount > 0 && (
+                 <li className="flex flex-col gap-1.5">
+                   <div className="flex justify-between items-center text-sm">
+                     <span className="text-gray-500">Comprehension</span>
+                     <span className={`font-bold text-sm ${status.comprehension >= 90 ? 'text-green-600' : status.comprehension >= 70 ? 'text-yellow-600' : 'text-red-500'}`}>
+                       {status.comprehension}% known
+                     </span>
+                   </div>
+                   <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                     <div
+                       className={`h-full rounded-full transition-all ${status.comprehension >= 90 ? 'bg-green-500' : status.comprehension >= 70 ? 'bg-yellow-400' : 'bg-red-400'}`}
+                       style={{ width: `${status.comprehension}%` }}
+                     />
+                   </div>
+                 </li>
+               )}
                <li className="flex justify-between items-center text-sm">
                  <span className="text-gray-500">Total Unique Words</span>
                  <span className="font-medium">{loading ? '-' : status.totalCount}</span>

--- a/src/components/ContentDetail.tsx
+++ b/src/components/ContentDetail.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { ArrowLeft, PlayCircle, GraduationCap, Loader2, BookOpen } from 'lucide-react';
+import { ArrowLeft, PlayCircle, GraduationCap, Loader2, BookOpen, Download } from 'lucide-react';
 import { Content } from '../data/content';
 import { WordInfo } from '../types';
 import { LessonProcess } from './LessonProcess';
 import { ContentReader } from './ContentReader';
+import { AnkiExportModal } from './AnkiExportModal';
 
 interface Status {
   difficulty: number;
@@ -15,30 +16,33 @@ interface Status {
   knownWords: WordInfo[];
 }
 
-export function ContentDetail({ 
-  content, 
-  onBack, 
-  status, 
+export function ContentDetail({
+  content,
+  onBack,
+  status,
   loading,
   markWordsAsKnown,
   onForceReload,
   onUpdateContent,
-  onAddWord
-}: { 
-  content: Content; 
-  onBack: () => void; 
-  status: Status; 
+  onAddWord,
+  knownWordSet,
+}: {
+  content: Content;
+  onBack: () => void;
+  status: Status;
   loading: boolean;
   markWordsAsKnown: (words: string[]) => void;
   onForceReload?: () => void;
   onUpdateContent?: (updatedContent: Content) => void;
   onAddWord?: (addedWordStr: string) => void;
+  knownWordSet?: Set<string>;
 }) {
   const [view, setView] = useState<'intro' | 'lesson' | 'consume'>('intro');
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(content.title);
   const [editText, setEditText] = useState(content.text);
   const [showAllWords, setShowAllWords] = useState(false);
+  const [showAnkiModal, setShowAnkiModal] = useState(false);
 
   if (view === 'lesson') {
     return (
@@ -141,7 +145,7 @@ export function ContentDetail({
                 >
                   Add Custom Word
                 </button>
-                <button 
+                <button
                   onClick={() => {
                     const data = {
                       content,
@@ -158,6 +162,13 @@ export function ContentDetail({
                   className="text-xs font-medium text-green-600 hover:text-green-800 bg-green-50 hover:bg-green-100 px-3 py-1.5 rounded-lg transition-colors"
                 >
                   Export Story JSON
+                </button>
+                <button
+                  onClick={() => setShowAnkiModal(true)}
+                  disabled={loading || status.totalCount === 0}
+                  className="text-xs font-medium text-purple-600 hover:text-purple-800 bg-purple-50 hover:bg-purple-100 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Download className="w-3.5 h-3.5" /> Export to Anki
                 </button>
                 {onForceReload && (
                   <button 
@@ -334,6 +345,15 @@ export function ContentDetail({
           </div>
         </div>
       </div>
+
+      {showAnkiModal && (
+        <AnkiExportModal
+          contentTitle={content.title}
+          words={[...status.unknownWords, ...status.knownWords]}
+          knownWordSet={knownWordSet ?? new Set()}
+          onClose={() => setShowAnkiModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import { Key, RefreshCw, CheckCircle, XCircle, Loader2, AlertCircle, Trash2 } from 'lucide-react';
+import { WK_STAGE_NAMES, loadCachedWaniKaniData } from '../lib/wanikani';
+
+interface WaniKaniUser {
+  username: string;
+  level: number;
+}
+
+type TokenStatus = 'idle' | 'testing' | 'valid' | 'invalid';
+type SyncStatus = 'idle' | 'syncing' | 'done' | 'error';
+
+export function SettingsPage({ onWaniKaniSync }: { onWaniKaniSync?: () => void }) {
+  const [token, setToken] = useState('');
+  const [tokenStatus, setTokenStatus] = useState<TokenStatus>('idle');
+  const [savedUser, setSavedUser] = useState<WaniKaniUser | null>(null);
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
+  const [syncInfo, setSyncInfo] = useState<{ kanjiCount: number; syncedAt: number } | null>(null);
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('waniKaniToken');
+    if (storedToken) setToken(storedToken);
+
+    const storedUser = localStorage.getItem('waniKaniUser');
+    if (storedUser) {
+      try { setSavedUser(JSON.parse(storedUser)); } catch { /* ignore */ }
+    }
+
+    const cached = loadCachedWaniKaniData();
+    if (cached) setSyncInfo({ kanjiCount: cached.kanjiCount, syncedAt: cached.syncedAt });
+  }, []);
+
+  const testToken = async () => {
+    if (!token.trim()) return;
+    setTokenStatus('testing');
+    try {
+      const res = await fetch('/api/wanikani/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: token.trim() }),
+      });
+      const data = await res.json();
+      if (data.valid) {
+        localStorage.setItem('waniKaniToken', token.trim());
+        const user = { username: data.username, level: data.level };
+        localStorage.setItem('waniKaniUser', JSON.stringify(user));
+        setSavedUser(user);
+        setTokenStatus('valid');
+      } else {
+        setTokenStatus('invalid');
+      }
+    } catch {
+      setTokenStatus('invalid');
+    }
+  };
+
+  const syncData = async () => {
+    const storedToken = localStorage.getItem('waniKaniToken');
+    if (!storedToken) return;
+    setSyncStatus('syncing');
+    try {
+      const res = await fetch('/api/wanikani/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: storedToken }),
+      });
+      if (!res.ok) throw new Error('Sync failed');
+      const result = await res.json();
+      // result: { data: Record<string,number>, kanjiCount: number }
+      const syncedAt = Date.now();
+      localStorage.setItem('waniKaniData', JSON.stringify({ data: result.data, syncedAt, kanjiCount: result.kanjiCount }));
+      setSyncInfo({ kanjiCount: result.kanjiCount, syncedAt });
+      setSyncStatus('done');
+      onWaniKaniSync?.();
+    } catch {
+      setSyncStatus('error');
+    }
+  };
+
+  const clearWaniKani = () => {
+    localStorage.removeItem('waniKaniToken');
+    localStorage.removeItem('waniKaniUser');
+    localStorage.removeItem('waniKaniData');
+    setToken('');
+    setSavedUser(null);
+    setSyncInfo(null);
+    setTokenStatus('idle');
+    setSyncStatus('idle');
+    onWaniKaniSync?.();
+  };
+
+  const hasValidToken = tokenStatus === 'valid' || (savedUser !== null && tokenStatus === 'idle');
+
+  return (
+    <section className="space-y-6 max-w-2xl">
+      <div className="mb-8">
+        <h2 className="text-2xl font-semibold tracking-tight mb-1">Settings</h2>
+        <p className="text-sm text-gray-500">Configure API integrations and personalization options.</p>
+      </div>
+
+      {/* WaniKani Integration */}
+      <div className="bg-white rounded-3xl border border-gray-100 shadow-sm overflow-hidden">
+        <div className="px-8 py-6 border-b border-gray-100 flex items-center gap-3">
+          <div className="bg-rose-50 p-2 rounded-xl">
+            <Key className="w-5 h-5 text-rose-600" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-gray-900">WaniKani API Key</h3>
+            <p className="text-xs text-gray-500 mt-0.5">Personalizes difficulty scores based on your SRS progress</p>
+          </div>
+          {savedUser && (
+            <div className="ml-auto flex items-center gap-2 bg-green-50 border border-green-100 px-3 py-1.5 rounded-full">
+              <CheckCircle className="w-3.5 h-3.5 text-green-600" />
+              <span className="text-xs font-semibold text-green-700">
+                {savedUser.username} · Level {savedUser.level}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="px-8 py-6 space-y-5">
+          <div>
+            <p className="text-sm text-gray-600 mb-3">
+              When connected, kanji difficulty scores are multiplied by your WaniKani SRS confidence level:
+            </p>
+            <div className="grid grid-cols-3 gap-2 text-xs text-gray-600 bg-gray-50 rounded-xl p-3">
+              {Object.entries(WK_STAGE_NAMES).map(([stage, name]) => (
+                <div key={stage} className="flex justify-between gap-1">
+                  <span className="text-gray-500">{name}</span>
+                  <span className="font-mono font-medium text-indigo-600">
+                    ×{stage === '1' ? '0.95' : stage === '2' ? '0.90' : stage === '3' ? '0.80' :
+                      stage === '4' ? '0.70' : stage === '5' ? '0.50' : stage === '6' ? '0.35' :
+                      stage === '7' ? '0.25' : stage === '8' ? '0.15' : '0.05'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-gray-700">API Token</label>
+            <div className="flex gap-2">
+              <input
+                type="password"
+                value={token}
+                onChange={e => { setToken(e.target.value); setTokenStatus('idle'); }}
+                onKeyDown={e => e.key === 'Enter' && testToken()}
+                placeholder="Paste your WaniKani v2 API token..."
+                className="flex-1 px-3 py-2 rounded-xl border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 font-mono"
+              />
+              <button
+                onClick={testToken}
+                disabled={!token.trim() || tokenStatus === 'testing'}
+                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-xl hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+              >
+                {tokenStatus === 'testing' ? (
+                  <><Loader2 className="w-4 h-4 animate-spin" /> Testing...</>
+                ) : 'Test & Save'}
+              </button>
+            </div>
+
+            {tokenStatus === 'valid' && (
+              <div className="flex items-center gap-2 text-green-700 text-sm">
+                <CheckCircle className="w-4 h-4" />
+                Token saved! Sync your data to apply WaniKani adjustments.
+              </div>
+            )}
+            {tokenStatus === 'invalid' && (
+              <div className="flex items-center gap-2 text-red-600 text-sm">
+                <XCircle className="w-4 h-4" />
+                Invalid token. Check your WaniKani API settings and try again.
+              </div>
+            )}
+
+            <p className="text-xs text-gray-400">
+              Find your token at{' '}
+              <span className="font-mono bg-gray-100 px-1 py-0.5 rounded">wanikani.com → Settings → API Tokens</span>
+            </p>
+          </div>
+
+          {hasValidToken && (
+            <div className="pt-4 border-t border-gray-100 space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-700">Sync SRS Data</p>
+                  {syncInfo ? (
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {syncInfo.kanjiCount} kanji synced · Last synced {new Date(syncInfo.syncedAt).toLocaleString()}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-gray-400 mt-0.5">Not yet synced — scores use static JLPT data</p>
+                  )}
+                </div>
+                <button
+                  onClick={syncData}
+                  disabled={syncStatus === 'syncing'}
+                  className="flex items-center gap-2 px-4 py-2 bg-indigo-50 text-indigo-700 text-sm font-medium rounded-xl hover:bg-indigo-100 border border-indigo-200 disabled:opacity-50 transition-colors"
+                >
+                  {syncStatus === 'syncing' ? (
+                    <><Loader2 className="w-4 h-4 animate-spin" /> Syncing...</>
+                  ) : (
+                    <><RefreshCw className="w-4 h-4" /> {syncInfo ? 'Re-sync' : 'Sync Now'}</>
+                  )}
+                </button>
+              </div>
+
+              {syncStatus === 'done' && (
+                <div className="flex items-center gap-2 text-green-700 text-sm bg-green-50 border border-green-100 rounded-lg px-3 py-2">
+                  <CheckCircle className="w-4 h-4 shrink-0" />
+                  Sync complete! Difficulty scores now reflect your WaniKani progress.
+                  Reload content to see updated scores.
+                </div>
+              )}
+              {syncStatus === 'error' && (
+                <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                  <AlertCircle className="w-4 h-4 shrink-0" />
+                  Sync failed. Check your connection and try again.
+                </div>
+              )}
+
+              <div className="pt-2">
+                <button
+                  onClick={clearWaniKani}
+                  className="flex items-center gap-2 text-xs text-red-500 hover:text-red-700 transition-colors"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                  Remove WaniKani integration
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -2,11 +2,23 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { WordInfo } from '../types';
 import { extractVocabulary } from '../lib/api';
 import { Content } from '../data/content';
+import { WaniKaniData, getWaniKaniMultiplier, loadCachedWaniKaniData } from '../lib/wanikani';
+
+function applyWaniKaniToWords(words: WordInfo[], wkData: WaniKaniData): WordInfo[] {
+  return words.map(word => {
+    const multiplier = getWaniKaniMultiplier(word.word, wkData);
+    if (multiplier === 1.0) return word;
+    const baseScore = word.baseScore ?? word.score;
+    const adjustedScore = Math.max(1, Math.round(baseScore * multiplier));
+    return { ...word, score: adjustedScore, baseScore, wkMultiplier: multiplier };
+  });
+}
 
 export function useContentData() {
   const [knownWords, setKnownWords] = useState<Set<string>>(new Set());
   const [contentVocab, setContentVocab] = useState<Record<string, WordInfo[]>>({});
   const [loadingContent, setLoadingContent] = useState<Record<string, boolean>>({});
+  const [wkData, setWkData] = useState<WaniKaniData | null>(null);
 
   // Load from local storage
   useEffect(() => {
@@ -45,7 +57,37 @@ export function useContentData() {
         console.error("Failed to parse content vocab from localStorage:", e);
       }
     }
+
+    const cached = loadCachedWaniKaniData();
+    if (cached) {
+      setWkData(cached.data);
+      console.log(`[WaniKani] Loaded ${cached.kanjiCount} kanji SRS entries from cache`);
+    }
   }, []);
+
+  // Re-apply WaniKani multipliers to all cached vocab when wkData changes
+  const wkDataRef = useRef<WaniKaniData | null>(null);
+  useEffect(() => {
+    wkDataRef.current = wkData;
+  }, [wkData]);
+
+  const applyWaniKaniToAllVocab = useCallback((data: WaniKaniData) => {
+    setContentVocab(prev => {
+      const next: Record<string, WordInfo[]> = {};
+      for (const [id, words] of Object.entries(prev) as [string, WordInfo[]][]) {
+        next[id] = applyWaniKaniToWords(words, data);
+      }
+      return next;
+    });
+  }, []);
+
+  const refreshWaniKaniData = useCallback(() => {
+    const cached = loadCachedWaniKaniData();
+    if (cached) {
+      setWkData(cached.data);
+      applyWaniKaniToAllVocab(cached.data);
+    }
+  }, [applyWaniKaniToAllVocab]);
 
   const markWordAsKnown = useCallback((word: string) => {
     setKnownWords(prev => {
@@ -86,8 +128,13 @@ export function useContentData() {
     setLoadingContent(prev => ({ ...prev, [content.id]: true }));
     console.log(`[Vocab] Loading vocabulary for "${content.id}"`);
     try {
-      const words = await extractVocabulary(content.text);
+      let words = await extractVocabulary(content.text);
       console.log(`[Vocab] Loaded ${words.length} words for "${content.id}"`);
+
+      if (wkDataRef.current) {
+        words = applyWaniKaniToWords(words, wkDataRef.current);
+      }
+
       setContentVocab(prev => {
         const next = { ...prev, [content.id]: words };
         localStorage.setItem('contentVocab', JSON.stringify(next));
@@ -109,26 +156,19 @@ export function useContentData() {
 
     const unknownWords = words.filter(w => !knownWords.has(w.word));
     const knownVocab = words.filter(w => knownWords.has(w.word));
-    
-    // Each word's score is roughly 1-100.
-    // The total difficulty of a piece of content should be the sum of all unknown word scores.
-    // A story with 5 words of score 10 (total 50) is easier than a story with 50 words of score 10 (total 500).
+
     const totalUnknownScore = unknownWords.reduce((acc, w) => acc + w.score, 0);
     const totalKnownScore = knownVocab.reduce((acc, w) => acc + w.score, 0);
-    
+
     const avgScore = unknownWords.length > 0 ? Math.round(totalUnknownScore / unknownWords.length) : 0;
-    
-    // The main sorting score should just be the totalUnknownScore + 0.5 * totalKnownScore
-    // This perfectly captures "# of unknown words" * "difficulty of those words"
-    // Plus a bit of difficulty for the sheer length / complexity of the known words
-    const difficultyScore = totalUnknownScore + (totalKnownScore * 0.5); 
+    const difficultyScore = totalUnknownScore + (totalKnownScore * 0.5);
 
     return {
-      difficulty: avgScore,          // average word difficulty (1-100)
-      totalUnknownScore,             // absolute difficulty score to sort by
+      difficulty: avgScore,
+      totalUnknownScore,
       unknownCount: unknownWords.length,
       totalCount: words.length,
-      score: difficultyScore,        // sort score
+      score: difficultyScore,
       unknownWords,
       knownWords: knownVocab
     };
@@ -149,7 +189,7 @@ export function useContentData() {
     setContentVocab(prev => {
       const next: Record<string, WordInfo[]> = {};
       let changed = false;
-      
+
       for (const [key, words] of Object.entries(prev) as [string, WordInfo[]][]) {
         let listChanged = false;
         const newWords = words.map(w => {
@@ -162,7 +202,7 @@ export function useContentData() {
         });
         next[key] = listChanged ? newWords : words;
       }
-      
+
       if (changed) {
         localStorage.setItem('contentVocab', JSON.stringify(next));
         return next;
@@ -175,6 +215,7 @@ export function useContentData() {
     knownWords,
     contentVocab,
     loadingContent,
+    wkData,
     markWordAsKnown,
     markWordsAsKnown,
     clearKnownWords,
@@ -182,6 +223,7 @@ export function useContentData() {
     loadVocabForContent,
     getContentStatus,
     updateWord,
-    setContentVocab
+    setContentVocab,
+    refreshWaniKaniData,
   };
 }

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -152,7 +152,7 @@ export function useContentData() {
   // If all words are known, difficulty is 0.
   const getContentStatus = useCallback((contentId: string) => {
     const words = contentVocab[contentId];
-    if (!words) return { difficulty: 0, unknownCount: 0, totalCount: 0, score: 0, totalUnknownScore: 0, unknownWords: [] };
+    if (!words) return { difficulty: 0, unknownCount: 0, totalCount: 0, score: 0, totalUnknownScore: 0, unknownWords: [], knownWords: [], comprehension: 0 };
 
     const unknownWords = words.filter(w => !knownWords.has(w.word));
     const knownVocab = words.filter(w => knownWords.has(w.word));
@@ -162,6 +162,7 @@ export function useContentData() {
 
     const avgScore = unknownWords.length > 0 ? Math.round(totalUnknownScore / unknownWords.length) : 0;
     const difficultyScore = totalUnknownScore + (totalKnownScore * 0.5);
+    const comprehension = words.length > 0 ? Math.round((knownVocab.length / words.length) * 100) : 0;
 
     return {
       difficulty: avgScore,
@@ -170,7 +171,8 @@ export function useContentData() {
       totalCount: words.length,
       score: difficultyScore,
       unknownWords,
-      knownWords: knownVocab
+      knownWords: knownVocab,
+      comprehension,
     };
   }, [contentVocab, knownWords]);
 

--- a/src/lib/anki.ts
+++ b/src/lib/anki.ts
@@ -1,0 +1,65 @@
+import { WordInfo } from '../types';
+
+export interface AnkiExportOptions {
+  deckName: string;
+  includeKnown: boolean;
+  jlptFilter: number[]; // empty = all levels
+}
+
+export function generateAnkiExport(
+  words: WordInfo[],
+  knownWordSet: Set<string>,
+  options: AnkiExportOptions
+): string {
+  let filtered = words;
+
+  if (!options.includeKnown) {
+    filtered = filtered.filter(w => !knownWordSet.has(w.word));
+  }
+
+  if (options.jlptFilter.length > 0) {
+    filtered = filtered.filter(w => options.jlptFilter.includes(w.jlpt));
+  }
+
+  // Deduplicate by word string
+  const seen = new Set<string>();
+  filtered = filtered.filter(w => {
+    if (seen.has(w.word)) return false;
+    seen.add(w.word);
+    return true;
+  });
+
+  const lines: string[] = [
+    '#separator:tab',
+    '#html:true',
+    `#deck:${options.deckName}`,
+    '#notetype:Basic',
+    '#columns:Front\tBack\tTags',
+    '',
+  ];
+
+  for (const word of filtered) {
+    const jlptTag = word.jlpt > 0 ? `JLPT_N${word.jlpt}` : 'JLPT_native';
+    const freqTags = (word.breakdown?.priorities ?? [])
+      .map(p => `freq_${p}`)
+      .join(' ');
+    const tags = [jlptTag, freqTags].filter(Boolean).join(' ');
+
+    const front = `<span style="font-size:2em;font-weight:bold">${word.word}</span><br><span style="color:#888;font-size:0.9em">${word.reading}</span>`;
+    const back = word.meaning;
+
+    lines.push(`${front}\t${back}\t${tags}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function downloadAnkiFile(content: string, filename: string) {
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/wanikani.ts
+++ b/src/lib/wanikani.ts
@@ -1,0 +1,67 @@
+// WaniKani SRS stage -> difficulty multiplier (per issue #9 specification)
+export const WK_MULTIPLIERS: Record<number, number> = {
+  1: 0.95, // Apprentice 1
+  2: 0.90, // Apprentice 2
+  3: 0.80, // Apprentice 3
+  4: 0.70, // Apprentice 4
+  5: 0.50, // Guru 1
+  6: 0.35, // Guru 2
+  7: 0.25, // Master
+  8: 0.15, // Enlightened
+  9: 0.05, // Burned
+};
+
+export const WK_STAGE_NAMES: Record<number, string> = {
+  1: 'Apprentice I',
+  2: 'Apprentice II',
+  3: 'Apprentice III',
+  4: 'Apprentice IV',
+  5: 'Guru I',
+  6: 'Guru II',
+  7: 'Master',
+  8: 'Enlightened',
+  9: 'Burned',
+};
+
+// Map from kanji character -> SRS stage (1–9)
+export type WaniKaniData = Record<string, number>;
+
+export interface WaniKaniSyncResult {
+  data: WaniKaniData;
+  syncedAt: number;
+  kanjiCount: number;
+}
+
+const KANJI_REGEX = /[一-龯]/g;
+
+export function getWaniKaniMultiplier(word: string, wkData: WaniKaniData): number {
+  const kanjis = word.match(KANJI_REGEX);
+  if (!kanjis || kanjis.length === 0) return 1.0;
+
+  // Use the minimum SRS stage (least confident kanji) to determine the multiplier.
+  // If a kanji hasn't been started in WaniKani, it contributes no adjustment.
+  let minStage: number | null = null;
+  for (const k of kanjis) {
+    const stage = wkData[k];
+    if (stage !== undefined) {
+      minStage = minStage === null ? stage : Math.min(minStage, stage);
+    }
+  }
+
+  if (minStage === null) return 1.0;
+  return WK_MULTIPLIERS[minStage] ?? 1.0;
+}
+
+export function loadCachedWaniKaniData(): WaniKaniSyncResult | null {
+  try {
+    const raw = localStorage.getItem('waniKaniData');
+    if (!raw) return null;
+    return JSON.parse(raw) as WaniKaniSyncResult;
+  } catch {
+    return null;
+  }
+}
+
+export function isCacheStale(cached: WaniKaniSyncResult, maxAgeMs = 24 * 60 * 60 * 1000): boolean {
+  return Date.now() - cached.syncedAt > maxAgeMs;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,11 @@ export interface WordInfo {
   word: string;
   reading: string;
   meaning: string;
-  jlpt: number;     // 1 to 5, where 5 is N5, 1 is N1, 0 if NA
+  jlpt: number;          // 1 to 5, where 5 is N5, 1 is N1, 0 if NA
   joyo: boolean;
-  score: number;    // 1-100 (1=beginner, 100=native)
+  score: number;         // 1-100 (1=beginner, 100=native), adjusted if WaniKani data available
+  baseScore?: number;    // original score before WaniKani adjustment
+  wkMultiplier?: number; // WaniKani SRS multiplier applied (0.05–1.0), undefined if no WK data
   breakdown?: ScoreBreakdown;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,12 @@ export interface WordInfo {
   word: string;
   reading: string;
   meaning: string;
-  jlpt: number;          // 1 to 5, where 5 is N5, 1 is N1, 0 if NA
+  jlpt: number;                  // 1 to 5, where 5 is N5, 1 is N1, 0 if NA
   joyo: boolean;
-  score: number;         // 1-100 (1=beginner, 100=native), adjusted if WaniKani data available
-  baseScore?: number;    // original score before WaniKani adjustment
-  wkMultiplier?: number; // WaniKani SRS multiplier applied (0.05–1.0), undefined if no WK data
+  score: number;                 // 1-100 (1=beginner, 100=native), adjusted if WaniKani data available
+  baseScore?: number;            // original score before WaniKani adjustment
+  wkMultiplier?: number;         // WaniKani SRS multiplier applied (0.05–1.0), undefined if no WK data
+  frequencyInContent?: number;   // how many times this word's base form appears in the source text
   breakdown?: ScoreBreakdown;
 }
 


### PR DESCRIPTION
Issue #9 - WaniKani API Integration:
- Add src/lib/wanikani.ts with SRS multipliers (Apprentice→Burned: 0.95x–0.05x)
- Add backend endpoints POST /api/wanikani/validate and /api/wanikani/sync
  (sync fetches kanji assignments + subjects, returns character→SRS stage map)
- Update useContentData hook to load cached WaniKani data on startup and apply
  multipliers to word scores whenever vocab is loaded or refreshed
- Add baseScore and wkMultiplier fields to WordInfo type

Issue #10 - Anki Deck Export:
- Add src/lib/anki.ts with generateAnkiExport() producing tab-separated
  Anki import format (.txt) with JLPT tags and HTML-formatted card fronts
- Add AnkiExportModal component with deck name input, JLPT filter, known-word
  toggle, preview count, and import instructions
- Add "Export to Anki" button on ContentDetail vocabulary overview

Settings Page:
- Add src/components/SettingsPage.tsx with WaniKani API token management:
  test/save token, sync SRS data, display sync status and user info
- Add Settings nav item to header (Settings icon + label)
- Wire onWaniKaniSync callback to refresh multipliers app-wide after sync

https://claude.ai/code/session_01T6gMPvisaoiwxxWKfkWGDz