### PR TITLE
Track WaniKani SRS stages and refine difficulty calculation

### DIFF
--- a/src/components/ContentDetail.tsx
+++ b/src/components/ContentDetail.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { ArrowLeft, PlayCircle, GraduationCap, Loader2, BookOpen, Download } from 'lucide-react';
+import { ArrowLeft, PlayCircle, GraduationCap, Loader2, BookOpen, Download, Zap } from 'lucide-react';
 import { Content } from '../data/content';
 import { WordInfo } from '../types';
+import { WK_STAGE_NAMES } from '../lib/wanikani';
 import { LessonProcess } from './LessonProcess';
 import { ContentReader } from './ContentReader';
 import { AnkiExportModal } from './AnkiExportModal';
@@ -239,6 +240,15 @@ export function ContentDetail({
                           <span>Freq. Penalty {w.breakdown?.priorities?.length ? `(${w.breakdown.priorities[0]})` : ''}</span>
                           <span>{w.breakdown?.freqPenalty > 0 ? '+' : ''}{w.breakdown?.freqPenalty || 0} pts</span>
                         </div>
+                        {w.wkSrsStage !== undefined && (
+                          <div className="flex justify-between text-gray-500 border-t border-gray-100 pt-1 mt-1">
+                            <span className="flex items-center gap-1.5">
+                              <Zap className="w-3 h-3" />
+                              {WK_STAGE_NAMES[w.wkSrsStage]}
+                            </span>
+                            <span>×{w.wkMultiplier?.toFixed(2) || '1.00'}</span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   ))}
@@ -278,6 +288,11 @@ export function ContentDetail({
                           <span className="text-sm text-gray-500">{w.reading}</span>
                         </div>
                         <div className="text-sm font-medium text-gray-600 mt-0.5">{w.meaning}</div>
+                        {w.wkSrsStage !== undefined && (
+                          <div className="text-xs text-gray-500 mt-1 flex items-center gap-1">
+                            <Zap className="w-3 h-3" /> {WK_STAGE_NAMES[w.wkSrsStage]}
+                          </div>
+                        )}
                       </div>
                       <div className="flex items-center gap-4 bg-gray-50 px-3 py-1.5 rounded-lg border border-gray-100 text-xs text-gray-500 min-w-fit">
                         <div>

--- a/src/components/WordDetailModal.tsx
+++ b/src/components/WordDetailModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { WordInfo, ScoreBreakdown } from '../types';
-import { X, Save } from 'lucide-react';
+import { X, Save, Zap } from 'lucide-react';
+import { WK_STAGE_NAMES } from '../lib/wanikani';
 
 export const WordDetailModal: React.FC<{
   w: WordInfo;
@@ -16,8 +17,10 @@ export const WordDetailModal: React.FC<{
   const [freqPenalty, setFreqPenalty] = useState(w.breakdown?.freqPenalty?.toString() || '0');
   const [priorities, setPriorities] = useState(w.breakdown?.priorities?.join(', ') || '');
   const [jlptScore, setJlptScore] = useState(w.breakdown?.jlptScore?.toString() || '0');
+  const [wkSrsStage, setWkSrsStage] = useState(w.wkSrsStage?.toString() || '');
 
   const handleSave = () => {
+    const stage = wkSrsStage !== '' ? parseInt(wkSrsStage) : undefined;
     const updated: WordInfo = {
       ...w,
       reading,
@@ -25,6 +28,7 @@ export const WordDetailModal: React.FC<{
       jlpt: parseInt(jlpt) || 0,
       joyo: highestGrade !== '' ? parseInt(highestGrade) <= 8 : w.joyo,
       score: parseInt(score) || 0,
+      wkSrsStage: stage,
       breakdown: {
         ...(w.breakdown || { jlptValues: [], gradeValues: [] }), // fallback
         jlptScore: parseInt(jlptScore) || 0,
@@ -150,6 +154,25 @@ export const WordDetailModal: React.FC<{
                   className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm font-mono"
                 />
               </div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-100 pt-6">
+            <h4 className="text-sm font-semibold text-gray-800 mb-4 uppercase tracking-widest flex items-center gap-2">
+              <Zap className="w-4 h-4" /> WaniKani Status
+            </h4>
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-gray-500">SRS Stage (1-9)</label>
+              <select
+                value={wkSrsStage}
+                onChange={e => setWkSrsStage(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm"
+              >
+                <option value="">Not in WaniKani</option>
+                {Object.entries(WK_STAGE_NAMES).map(([stage, name]) => (
+                  <option key={stage} value={stage}>{stage} - {name}</option>
+                ))}
+              </select>
             </div>
           </div>
         </div>

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -172,10 +172,17 @@ export function useContentData() {
     const knownVocab = words.filter(w => isWordKnown(w));
 
     const totalUnknownScore = unknownWords.reduce((acc, w) => acc + w.score, 0);
-    const totalKnownScore = knownVocab.reduce((acc, w) => acc + w.score, 0);
+
+    // Known words reduce difficulty, but use WaniKani multiplier if available, otherwise 0.5
+    const totalKnownScore = knownVocab.reduce((acc, w) => {
+      if (w.wkSrsStage !== undefined) {
+        return acc + w.score; // Already has WaniKani multiplier applied
+      }
+      return acc + (w.score * 0.5); // Manually marked as known: apply 0.5 reduction
+    }, 0);
 
     const avgScore = unknownWords.length > 0 ? Math.round(totalUnknownScore / unknownWords.length) : 0;
-    const difficultyScore = totalUnknownScore + (totalKnownScore * 0.5);
+    const difficultyScore = totalUnknownScore + totalKnownScore;
     const comprehension = words.length > 0 ? Math.round((knownVocab.length / words.length) * 100) : 0;
 
     return {

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -157,12 +157,19 @@ export function useContentData() {
 
   // Difficulty is the average difficulty of UNKNOWN words.
   // If all words are known, difficulty is 0.
+  // Words are considered known if: manually marked OR WaniKani SRS stage >= 7 (Master and above)
+  const isWordKnown = useCallback((word: WordInfo): boolean => {
+    if (knownWords.has(word.word)) return true;
+    if (word.wkSrsStage !== undefined && word.wkSrsStage >= 7) return true;
+    return false;
+  }, [knownWords]);
+
   const getContentStatus = useCallback((contentId: string) => {
     const words = contentVocab[contentId];
     if (!words) return { difficulty: 0, unknownCount: 0, totalCount: 0, score: 0, totalUnknownScore: 0, unknownWords: [], knownWords: [], comprehension: 0 };
 
-    const unknownWords = words.filter(w => !knownWords.has(w.word));
-    const knownVocab = words.filter(w => knownWords.has(w.word));
+    const unknownWords = words.filter(w => !isWordKnown(w));
+    const knownVocab = words.filter(w => isWordKnown(w));
 
     const totalUnknownScore = unknownWords.reduce((acc, w) => acc + w.score, 0);
     const totalKnownScore = knownVocab.reduce((acc, w) => acc + w.score, 0);
@@ -181,7 +188,7 @@ export function useContentData() {
       knownWords: knownVocab,
       comprehension,
     };
-  }, [contentVocab, knownWords]);
+  }, [contentVocab, isWordKnown]);
 
   const clearKnownWords = useCallback(() => {
     setKnownWords(new Set());

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -2,15 +2,22 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { WordInfo } from '../types';
 import { extractVocabulary } from '../lib/api';
 import { Content } from '../data/content';
-import { WaniKaniData, getWaniKaniMultiplier, loadCachedWaniKaniData } from '../lib/wanikani';
+import { WaniKaniData, getWaniKaniMultiplier, getWaniKaniSrsStage, loadCachedWaniKaniData } from '../lib/wanikani';
 
 function applyWaniKaniToWords(words: WordInfo[], wkData: WaniKaniData): WordInfo[] {
   return words.map(word => {
+    const srsStage = getWaniKaniSrsStage(word.word, wkData);
     const multiplier = getWaniKaniMultiplier(word.word, wkData);
-    if (multiplier === 1.0) return word;
+
+    const updatedWord: WordInfo = { ...word };
+    if (srsStage !== null) {
+      updatedWord.wkSrsStage = srsStage;
+    }
+
+    if (multiplier === 1.0) return updatedWord;
     const baseScore = word.baseScore ?? word.score;
     const adjustedScore = Math.max(1, Math.round(baseScore * multiplier));
-    return { ...word, score: adjustedScore, baseScore, wkMultiplier: multiplier };
+    return { ...updatedWord, score: adjustedScore, baseScore, wkMultiplier: multiplier };
   });
 }
 

--- a/src/lib/wanikani.ts
+++ b/src/lib/wanikani.ts
@@ -35,10 +35,16 @@ export interface WaniKaniSyncResult {
 const KANJI_REGEX = /[一-龯]/g;
 
 export function getWaniKaniMultiplier(word: string, wkData: WaniKaniData): number {
-  const kanjis = word.match(KANJI_REGEX);
-  if (!kanjis || kanjis.length === 0) return 1.0;
+  const stage = getWaniKaniSrsStage(word, wkData);
+  if (stage === null) return 1.0;
+  return WK_MULTIPLIERS[stage] ?? 1.0;
+}
 
-  // Use the minimum SRS stage (least confident kanji) to determine the multiplier.
+export function getWaniKaniSrsStage(word: string, wkData: WaniKaniData): number | null {
+  const kanjis = word.match(KANJI_REGEX);
+  if (!kanjis || kanjis.length === 0) return null;
+
+  // Use the minimum SRS stage (least confident kanji) to determine the stage.
   // If a kanji hasn't been started in WaniKani, it contributes no adjustment.
   let minStage: number | null = null;
   for (const k of kanjis) {
@@ -48,8 +54,7 @@ export function getWaniKaniMultiplier(word: string, wkData: WaniKaniData): numbe
     }
   }
 
-  if (minStage === null) return 1.0;
-  return WK_MULTIPLIERS[minStage] ?? 1.0;
+  return minStage;
 }
 
 export function loadCachedWaniKaniData(): WaniKaniSyncResult | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface WordInfo {
   score: number;                 // 1-100 (1=beginner, 100=native), adjusted if WaniKani data available
   baseScore?: number;            // original score before WaniKani adjustment
   wkMultiplier?: number;         // WaniKani SRS multiplier applied (0.05–1.0), undefined if no WK data
+  wkSrsStage?: number;           // WaniKani SRS stage (1-9), undefined if not in WaniKani
   frequencyInContent?: number;   // how many times this word's base form appears in the source text
   breakdown?: ScoreBreakdown;
 }


### PR DESCRIPTION
## Summary
This PR adds support for tracking WaniKani SRS stages on individual words and refines how known words contribute to content difficulty scoring. Previously, the system only applied WaniKani multipliers to word scores. Now it explicitly tracks the SRS stage for each word and uses that information to determine whether a word is "known" (manually marked OR WaniKani Master+ stage).

## Key Changes

- **New `getWaniKaniSrsStage()` function**: Extracted SRS stage detection logic from the multiplier calculation. Returns the minimum SRS stage across all kanji in a word, or null if not in WaniKani.

- **Added `wkSrsStage` field to `WordInfo`**: Words now store their WaniKani SRS stage (1-9) separately from the multiplier, enabling more granular tracking and display.

- **Refined "known word" definition**: Words are now considered known if either:
  - Manually marked as known, OR
  - Have a WaniKani SRS stage ≥ 7 (Master and above)

- **Improved difficulty calculation**: 
  - Known words from WaniKani already have the multiplier applied to their score, so they contribute their full adjusted score to difficulty
  - Manually marked known words get a 0.5 reduction applied (representing partial knowledge)
  - This prevents double-counting the WaniKani adjustment

- **UI enhancements**:
  - Added WaniKani Status section to WordDetailModal with SRS stage selector
  - Display WaniKani SRS stage and multiplier in word breakdowns in ContentDetail
  - Added Zap icon to indicate WaniKani-tracked words

## Implementation Details

- The `applyWaniKaniToWords()` function now populates `wkSrsStage` on all words before calculating multipliers
- The `isWordKnown()` callback consolidates the logic for determining word knowledge status
- Difficulty scoring now correctly distinguishes between WaniKani-adjusted and manually-marked known words

https://claude.ai/code/session_014rx8EvTWpRcQTfkTeJ3i83