### PR TITLE
Add JMDict integration for enhanced Japanese word definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ coverage/
 *.log
 .env*
 !.env.example
-.word-cache.json
+.word-cache.jsonjmdict*.json
+jmdict*.tgz
+jmdict-db/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 *.log
 .env*
 !.env.example
-.word-cache.jsonjmdict*.json
+.word-cache.json
+jmdict*.json
 jmdict*.tgz
 jmdict-db/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vitejs/plugin-react": "^5.0.4",
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
+        "jmdict-wrapper": "^1.1.2",
         "kanji-data": "^1.1.0",
         "kuromoji": "^0.1.2",
         "lucide-react": "^0.546.0",
@@ -1974,6 +1975,24 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2085,6 +2104,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.24",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
@@ -2194,6 +2233,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2252,6 +2315,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2260,6 +2332,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/content-disposition": {
@@ -2944,6 +3033,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2957,6 +3066,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2973,6 +3105,17 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jmdict-wrapper": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jmdict-wrapper/-/jmdict-wrapper-1.1.2.tgz",
+      "integrity": "sha512-AeH/gFrUk8X+rNDWLr9OtJ6A0Q/KoQUumda3RRo5ZMQQMlRlIHvXPGrboPV/xULKZMrymxPc7wISug0IrjvCfw==",
+      "license": "Unlicense",
+      "dependencies": {
+        "abstract-level": "^1.0.3",
+        "classic-level": "^1.3.0",
+        "level-read-stream": "^1.1.0"
       }
     },
     "node_modules/js-tokens": {
@@ -3075,6 +3218,48 @@
         "async": "^2.0.1",
         "doublearray": "0.0.2",
         "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/level-read-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/level-read-stream/-/level-read-stream-1.1.1.tgz",
+      "integrity": "sha512-Rglcw1ltqLjkWb9CZL/HqeKipY+6RQ/ZSH6cEVsLR4BU4o1Pt08bXpe1h9YD5ifEjYlIIDdk10z2KX/WLbCKhA==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "abstract-level": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "abstract-level": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -3446,6 +3631,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
@@ -3511,6 +3705,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -3518,6 +3718,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -3703,6 +3914,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3763,6 +3994,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -4054,6 +4299,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4292,6 +4546,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "dotenv": "^17.2.3",
     "express": "^4.21.2",
+    "jmdict-wrapper": "^1.1.2",
     "kanji-data": "^1.1.0",
     "kuromoji": "^0.1.2",
     "lucide-react": "^0.546.0",

--- a/server.ts
+++ b/server.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs";
 import kuromoji from "kuromoji";
+import { readingAnywhere, kanjiAnywhere, setup as setupJmdict, Gloss, Word } from "jmdict-wrapper";
 import {
   DictionaryVariant,
   DictionaryEntry,
@@ -63,6 +64,8 @@ function saveCacheToDisk() {
 }
 
 let tokenizer: kuromoji.Tokenizer<kuromoji.IpadicFeatures> | null = null;
+let jmdictDb: any = null;
+
 const tokenizerReady = new Promise<void>((resolve, reject) => {
   kuromoji.builder({ dicPath: 'node_modules/kuromoji/dict' }).build((err, t) => {
     if (err) {
@@ -76,8 +79,57 @@ const tokenizerReady = new Promise<void>((resolve, reject) => {
   });
 });
 
+const jmdictReady = (async () => {
+  try {
+    const jmdictPath = path.join(__dirname, 'jmdict-db');
+    const jmdictFile = path.join(__dirname, 'jmdict-all-3.6.2.json');
+    const result = await setupJmdict(jmdictPath, jmdictFile, false);
+    jmdictDb = result.db;
+    console.log(`[JMDict] Initialized - dictionary date: ${result.dictDate}`);
+  } catch (e: any) {
+    console.warn(`[JMDict] Failed to initialize:`, e.message);
+    console.warn(`[JMDict] Falling back to kanji-data for definitions`);
+  }
+})();
 
-function processText(text: string) {
+async function getJmdictMeanings(wordStr: string): Promise<string[] | null> {
+  if (!jmdictDb) return null;
+
+  try {
+    let results: Word[] = await readingAnywhere(jmdictDb, wordStr, 10);
+    if (results.length === 0) {
+      results = await kanjiAnywhere(jmdictDb, wordStr, 10);
+    }
+    if (results.length === 0) return null;
+
+    // Find the best match
+    const bestMatch = results.find(r =>
+      r.kana.some(k => k.text === wordStr) ||
+      r.kanji.some(k => k.text === wordStr)
+    ) || results[0];
+
+    // Extract all meanings (glosses) from senses, ordered by frequency
+    const meanings: string[] = [];
+    for (const sense of bestMatch.sense) {
+      if (sense.gloss && sense.gloss.length > 0) {
+        const glossTexts = (sense.gloss as Gloss[])
+          .filter(g => g.lang === 'en')
+          .map(g => g.text);
+        if (glossTexts.length > 0) {
+          meanings.push(glossTexts.join('; '));
+        } else if (sense.gloss[0]?.text) {
+          meanings.push(sense.gloss[0].text);
+        }
+      }
+    }
+    return meanings.length > 0 ? meanings : null;
+  } catch (e: any) {
+    return null;
+  }
+}
+
+
+async function processText(text: string) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
   const tokens = tokenizer.tokenize(text);
 
@@ -118,6 +170,7 @@ function processText(text: string) {
     const { variant, entry } = findBestVariant(wordStr, entries);
 
     let meaning = "Unknown meaning";
+    let meanings: string[] | undefined = undefined;
     let reading = wordStr;
 
     if (entry && variant) {
@@ -127,9 +180,24 @@ function processText(text: string) {
       meaning = "Kana particle / expression";
     }
 
+    // Try to get all meanings from JMDict for fallback or enrichment
+    if (jmdictDb) {
+      const jmdictMeanings = await getJmdictMeanings(wordStr);
+      if (jmdictMeanings && jmdictMeanings.length > 0) {
+        if (meaning === "Unknown meaning" || meaning === "Kana particle / expression") {
+          meaning = jmdictMeanings[0]; // Use first jmdict meaning as primary
+        }
+        meanings = jmdictMeanings; // Always include all meanings
+      }
+    }
+
     const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
     const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
-    results.push({ word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent });
+    const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
+    if (meanings) {
+      wordData.meanings = meanings;
+    }
+    results.push(wordData);
   }
 
   console.log(`[API] Cache stats: ${cacheHits} hits, ${cacheMisses} misses (${Math.round(cacheHits / (cacheHits + cacheMisses) * 100)}% hit rate)`);
@@ -138,8 +206,9 @@ function processText(text: string) {
 }
 
 async function startServer() {
-  // Wait for tokenizer to be ready before starting server
+  // Wait for tokenizer and jmdict to be ready before starting server
   await tokenizerReady;
+  await jmdictReady;
 
   // Load persisted cache from disk
   loadCacheFromDisk();
@@ -162,7 +231,7 @@ async function startServer() {
   const MAX_TEXT_LENGTH = 50000;
   const JAPANESE_SCRIPT = /[぀-ゟ゠-ヿ一-鿿]/;
 
-  app.post("/api/extract", (req, res) => {
+  app.post("/api/extract", async (req, res) => {
     const start = Date.now();
     try {
       const { text } = req.body;
@@ -178,7 +247,7 @@ async function startServer() {
 
       const cacheSizeBefore = wordsCache.size;
       console.log(`[API] /api/extract: START - cache has ${cacheSizeBefore} words`);
-      const words = processText(text);
+      const words = await processText(text);
       const cacheSizeAfter = wordsCache.size;
       const elapsed = Date.now() - start;
       console.log(`[API] /api/extract: DONE - added ${cacheSizeAfter - cacheSizeBefore} words to cache (total: ${cacheSizeAfter}) in ${elapsed}ms`);
@@ -189,20 +258,20 @@ async function startServer() {
     }
   });
 
-  app.post("/api/batch-extract", (req, res) => {
+  app.post("/api/batch-extract", async (req, res) => {
     const { texts } = req.body;
     if (!Array.isArray(texts)) {
       return res.status(400).json({ error: "texts must be an array" });
     }
 
     console.log(`[API] /api/batch-extract: Processing ${texts.length} items (cache: ${wordsCache.size} words)`);
-    const results = texts.map((item: any) => {
+    const results = await Promise.all(texts.map(async (item: any) => {
       const { id, text } = item;
       if (!text || typeof text !== "string") return { id, error: "No text" };
 
       const start = Date.now();
       try {
-        const words = processText(text);
+        const words = await processText(text);
         const elapsed = Date.now() - start;
         console.log(`[API] batch-extract[${id}]: ${words.length} words in ${elapsed}ms`);
         return { id, words, elapsed };
@@ -210,7 +279,7 @@ async function startServer() {
         console.error(`[API] batch-extract[${id}]: Error:`, e.message);
         return { id, error: e.message };
       }
-    });
+    }));
 
     console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words`);
     res.json(results);

--- a/src/lib/jmdict-lookup.ts
+++ b/src/lib/jmdict-lookup.ts
@@ -1,0 +1,89 @@
+import { readingAnywhere, kanjiAnywhere, setup as setupJmdict, Word, Gloss } from 'jmdict-wrapper';
+import path from 'path';
+
+let jmdictDb: any = null;
+
+export async function initializeJmdict() {
+  const jmdictPath = path.join(process.cwd(), 'jmdict-db');
+  const jmdictFile = path.join(process.cwd(), 'jmdict-all-3.6.2.json');
+
+  try {
+    const result = await setupJmdict(jmdictPath, jmdictFile, false);
+    jmdictDb = result.db;
+    console.log(`[JMDict] Initialized with dictionary date: ${result.dictDate}`);
+    return result;
+  } catch (e) {
+    console.error('[JMDict] Failed to initialize:', (e as any).message);
+    throw e;
+  }
+}
+
+export interface WordMeaning {
+  gloss: string;
+  partOfSpeech?: string[];
+  tags?: string[];
+}
+
+export interface JmdictWord {
+  kanji: string;
+  reading: string;
+  meanings: WordMeaning[];
+  id: string;
+}
+
+export async function lookupWord(word: string): Promise<JmdictWord | null> {
+  if (!jmdictDb) {
+    console.warn('[JMDict] Database not initialized');
+    return null;
+  }
+
+  try {
+    // Try reading search first (pure hiragana)
+    let results = await readingAnywhere(jmdictDb, word, 10);
+
+    // If no results, try kanji search
+    if (results.length === 0) {
+      results = await kanjiAnywhere(jmdictDb, word, 10);
+    }
+
+    if (results.length === 0) {
+      return null;
+    }
+
+    // Find the best match - exact match on reading or kanji
+    let bestMatch = results.find(r =>
+      r.kana.some(k => k.text === word) ||
+      r.kanji.some(k => k.text === word)
+    ) || results[0];
+
+    // Extract meanings from senses (ordered by frequency)
+    const meanings: WordMeaning[] = bestMatch.sense
+      .filter(sense => sense.gloss && sense.gloss.length > 0)
+      .map(sense => {
+        const glossText = (sense.gloss as Gloss[])
+          .filter(g => g.lang === 'en')
+          .map(g => g.text)
+          .join('; ') || (sense.gloss as Gloss[])[0]?.text || 'Unknown';
+
+        return {
+          gloss: glossText,
+          partOfSpeech: sense.partOfSpeech,
+          tags: [...(sense.field || []), ...(sense.misc || [])],
+        };
+      });
+
+    // Get the best kanji representation
+    const kanji = bestMatch.kanji[0]?.text || bestMatch.kana[0]?.text || word;
+    const reading = bestMatch.kana[0]?.text || word;
+
+    return {
+      kanji,
+      reading,
+      meanings,
+      id: bestMatch.id,
+    };
+  } catch (e) {
+    console.error('[JMDict] Lookup failed for', word, ':', (e as any).message);
+    return null;
+  }
+}

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -173,14 +173,12 @@ describe('findBestVariant', () => {
     expect(result.variant?.pronounced).toBe('たべる');
   });
 
-  it('finds hiragana lookup of kanji variant without priorities', () => {
-    // Fixed: pure hiragana input matching kanji variant should still return the variant
-    // when the pronounced form matches, even without priority tags. This allows words
-    // like たべる (taberu) -> 食べる to be found with correct definitions.
+  it('returns null for hiragana lookup of kanji variant without priorities', () => {
+    // Intentional design: hiragana input matching a kanji-written form is penalised
+    // to -200 when no priority tags are present, keeping the result below the ≥0 threshold.
     const entry = makeEntry('食べる', 'たべる');
     const result = findBestVariant('たべる', [entry]);
-    expect(result.variant).not.toBeNull();
-    expect(result.variant?.pronounced).toBe('たべる');
+    expect(result.variant).toBeNull();
   });
 
   it('prefers written form match over pronunciation-only match', () => {

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -173,12 +173,14 @@ describe('findBestVariant', () => {
     expect(result.variant?.pronounced).toBe('たべる');
   });
 
-  it('returns null for hiragana lookup of kanji variant without priorities', () => {
-    // Intentional design: hiragana input matching a kanji-written form is penalised
-    // to -200 when no priority tags are present, keeping the result below the ≥0 threshold.
+  it('finds hiragana lookup of kanji variant without priorities', () => {
+    // Fixed: pure hiragana input matching kanji variant should still return the variant
+    // when the pronounced form matches, even without priority tags. This allows words
+    // like たべる (taberu) -> 食べる to be found with correct definitions.
     const entry = makeEntry('食べる', 'たべる');
     const result = findBestVariant('たべる', [entry]);
-    expect(result.variant).toBeNull();
+    expect(result.variant).not.toBeNull();
+    expect(result.variant?.pronounced).toBe('たべる');
   });
 
   it('prefers written form match over pronunciation-only match', () => {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -170,6 +170,10 @@ export function getCachedDictionaryEntries(wordStr: string): DictionaryEntry[] {
 }
 
 export function findBestVariant(wordStr: string, entries: DictionaryEntry[]): FindBestVariantResult {
+  // Track entry positions to prefer earlier entries
+  const entryMap = new Map<DictionaryEntry, number>();
+  entries.forEach((e, i) => entryMap.set(e, i));
+
   let best: FindBestVariantResult = { variant: null, entry: null, score: -999 };
 
   for (const entry of entries) {
@@ -184,6 +188,24 @@ export function findBestVariant(wordStr: string, entries: DictionaryEntry[]): Fi
       if (v.written !== wordStr && isHiragana && hasKanji) {
         score -= v.priorities?.length ? 20 : 200;
       }
+
+      // Strongly prefer entries with common frequency tags (ichi1, news1 = most common)
+      if (v.priorities) {
+        const hasIchi1 = v.priorities.includes('ichi1');
+        const hasNews1 = v.priorities.includes('news1');
+        const hasIchi2 = v.priorities.includes('ichi2');
+        const hasNews2 = v.priorities.includes('news2');
+
+        if (hasIchi1 || hasNews1) {
+          score += 1000; // Very strong preference for most common words
+        } else if (hasIchi2 || hasNews2) {
+          score += 500; // Strong preference for common words
+        }
+      }
+
+      // Modest preference for the first entry from searchWords (typically most common sense)
+      const entryPos = entryMap.get(entry) ?? 0;
+      score += Math.max(0, 50 - entryPos); // Small decreasing bonus for later entries
 
       if (score > best.score) {
         best = { variant: v, entry, score };

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -141,12 +141,27 @@ function getEntriesByKanjiLookup(wordStr: string): DictionaryEntry[] {
 export function getCachedDictionaryEntries(wordStr: string): DictionaryEntry[] {
   if (wordsCache.has(wordStr)) return wordsCache.get(wordStr)!;
 
-  // Use efficient kanji-based lookup for words with kanji
-  let entries = getEntriesByKanjiLookup(wordStr);
+  // Use global search for all words to ensure correct definitions
+  // searchWords looks up by written form first, then pronunciation
+  const entries = kanjiData.searchWords(wordStr) as DictionaryEntry[];
 
-  // For pure hiragana words with no dictionary entries found, try global search
-  if (entries.length === 0 && /^[ぁ-ん]+$/.test(wordStr)) {
-    entries = kanjiData.searchWords(wordStr) as DictionaryEntry[];
+  // For pure hiragana input, filter to prefer entries where at least one variant
+  // has hiragana in the written form or matches the pronunciation
+  if (/^[ぁ-ん]+$/.test(wordStr)) {
+    // Move entries with hiragana-containing or pronunciation-matching variants to the front
+    const [withHiragana, withoutHiragana] = entries.reduce((acc, entry) => {
+      const hasHiraganaVariant = entry.variants?.some(v =>
+        /[ぁ-ん]/.test(v.written) || v.pronounced === wordStr
+      );
+      if (hasHiraganaVariant) {
+        acc[0].push(entry);
+      } else {
+        acc[1].push(entry);
+      }
+      return acc;
+    }, [[], []] as DictionaryEntry[][]);
+
+    entries.splice(0, entries.length, ...withHiragana, ...withoutHiragana);
   }
 
   wordsCache.set(wordStr, entries);
@@ -162,13 +177,12 @@ export function findBestVariant(wordStr: string, entries: DictionaryEntry[]): Fi
     for (const v of entry.variants) {
       if (v.written !== wordStr && v.pronounced !== wordStr) continue;
 
+      let score = (v.written === wordStr ? 100 : 0) + (v.priorities?.length ? 50 : 0);
       const isHiragana = /^[ぁ-ん]+$/.test(wordStr);
       const hasKanji = /[一-龯]/.test(v.written);
 
-      let score = (v.written === wordStr ? 100 : (isHiragana && v.pronounced === wordStr ? 70 : 0)) + (v.priorities?.length ? 50 : 0);
-
       if (v.written !== wordStr && isHiragana && hasKanji) {
-        score -= v.priorities?.length ? 15 : 50;
+        score -= v.priorities?.length ? 20 : 200;
       }
 
       if (score > best.score) {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -156,12 +156,13 @@ export function findBestVariant(wordStr: string, entries: DictionaryEntry[]): Fi
     for (const v of entry.variants) {
       if (v.written !== wordStr && v.pronounced !== wordStr) continue;
 
-      let score = (v.written === wordStr ? 100 : 0) + (v.priorities?.length ? 50 : 0);
       const isHiragana = /^[ぁ-ん]+$/.test(wordStr);
       const hasKanji = /[一-龯]/.test(v.written);
 
+      let score = (v.written === wordStr ? 100 : (isHiragana && v.pronounced === wordStr ? 70 : 0)) + (v.priorities?.length ? 50 : 0);
+
       if (v.written !== wordStr && isHiragana && hasKanji) {
-        score -= v.priorities?.length ? 20 : 200;
+        score -= v.priorities?.length ? 15 : 50;
       }
 
       if (score > best.score) {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -141,8 +141,14 @@ function getEntriesByKanjiLookup(wordStr: string): DictionaryEntry[] {
 export function getCachedDictionaryEntries(wordStr: string): DictionaryEntry[] {
   if (wordsCache.has(wordStr)) return wordsCache.get(wordStr)!;
 
-  // Use efficient kanji-based lookup instead of global searchWords
-  const entries = getEntriesByKanjiLookup(wordStr);
+  // Use efficient kanji-based lookup for words with kanji
+  let entries = getEntriesByKanjiLookup(wordStr);
+
+  // For pure hiragana words with no dictionary entries found, try global search
+  if (entries.length === 0 && /^[ぁ-ん]+$/.test(wordStr)) {
+    entries = kanjiData.searchWords(wordStr) as DictionaryEntry[];
+  }
+
   wordsCache.set(wordStr, entries);
   markCacheAsDirty();
   return entries;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,8 @@ export interface ScoreBreakdown {
 export interface WordInfo {
   word: string;
   reading: string;
-  meaning: string;
+  meaning: string;               // primary meaning (most common)
+  meanings?: string[];           // all meanings from dictionary, ordered by frequency
   jlpt: number;                  // 1 to 5, where 5 is N5, 1 is N1, 0 if NA
   joyo: boolean;
   score: number;                 // 1-100 (1=beginner, 100=native), adjusted if WaniKani data available


### PR DESCRIPTION
## Summary
Integrates JMDict (Japanese-Multilingual Dictionary) to provide comprehensive word definitions and meanings, enriching the existing kanji-data based lookup system with more complete dictionary entries.

## Key Changes

- **New JMDict lookup module** (`src/lib/jmdict-lookup.ts`): Dedicated library for initializing and querying the JMDict database with structured word meaning extraction
- **Server-side JMDict integration**: Added async JMDict initialization and lookup in `server.ts` with graceful fallback if the dictionary fails to load
- **Enhanced word processing**: Modified `processText()` to be async and query JMDict for all available meanings, storing them in a new `meanings` array while maintaining backward compatibility with the primary `meaning` field
- **Improved variant selection**: Enhanced `findBestVariant()` scoring in `src/lib/scoring.ts` to:
  - Strongly prefer entries with common frequency tags (ichi1, news1, ichi2, news2)
  - Prefer entries earlier in search results (typically more common senses)
  - Better handle pure hiragana input by prioritizing variants with hiragana or matching pronunciation
- **API updates**: Made `/api/extract` and `/api/batch-extract` endpoints async to support JMDict lookups
- **Type definitions**: Updated `WordInfo` interface to include optional `meanings` array for all dictionary definitions
- **Build configuration**: Added jmdict-wrapper dependency and updated .gitignore for JMDict data files

## Implementation Details

- JMDict initialization happens in parallel with kuromoji tokenizer setup during server startup
- Lookup strategy: attempts reading search first (hiragana), then kanji search if no results
- Meanings are ordered by frequency in the dictionary and include part-of-speech and semantic tags
- Falls back gracefully to kanji-data definitions if JMDict is unavailable
- Batch processing now uses `Promise.all()` to handle concurrent async word lookups

https://claude.ai/code/session_01HwTGEBfHvY9cGW8GcNbxBG