### PR TITLE
Add debug logging to dictionary lookups and improve fallback logic

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -191,10 +191,10 @@ async function processText(text: string) {
       meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
     }
 
-    // Use Jisho API for pure hiragana words (particles, auxiliaries)
-    // Queuing system prevents overwhelming the API
+    // Use dictionary (Jisho API or jmdict) for pure hiragana words first
+    // These are particles, auxiliaries, and other hiragana-only words where kanji-data is unreliable
     const isPureHiragana = /^[ぁ-ん]+$/.test(wordStr);
-    if (isPureHiragana && dictionary && meaning === "Unknown meaning") {
+    if (isPureHiragana && dictionary) {
       const dictResult = await dictionary.lookup(wordStr);
       if (dictResult) {
         meaning = dictResult.meaning;
@@ -204,7 +204,7 @@ async function processText(text: string) {
       }
     }
 
-    // Fallback for pure hiragana particles if still no result
+    // Fallback for pure hiragana particles if still no result from dictionary
     if (meaning === "Unknown meaning" && isPureHiragana) {
       meaning = "Kana particle / expression";
     }

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -265,9 +265,10 @@ export class DictionaryManager {
         await (this.fallback as JishoApiDictionary).initialize();
         return;
       }
+      // If jmdict failed, fall through to try jisho
     }
 
-    if (usePrimary === "jisho") {
+    if (usePrimary === "jisho" || usePrimary === "jmdict") {
       const jishoDict = new JishoApiDictionary();
       await jishoDict.initialize();
       if (jishoDict.isInitialized()) {

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -31,9 +31,15 @@ export class KanjiDataDictionary implements Dictionary {
   }
 
   async lookup(word: string): Promise<WordLookupResult | null> {
-    if (!this.searchWords || typeof this.searchWords !== 'function') return null;
+    if (!this.searchWords || typeof this.searchWords !== 'function') {
+      console.log(`[Dictionary.KanjiData] searchWords not available`);
+      return null;
+    }
     const entries = this.searchWords(word) as any[];
-    if (!entries || entries.length === 0) return null;
+    if (!entries || entries.length === 0) {
+      console.log(`[Dictionary.KanjiData] No entries for "${word}"`);
+      return null;
+    }
 
     // For pure hiragana, prefer entries with matching pronunciation
     let bestEntry = entries[0];
@@ -50,6 +56,7 @@ export class KanjiDataDictionary implements Dictionary {
     }
 
     const firstMeaning = bestEntry.meanings?.[0]?.glosses?.[0] || "Unknown";
+    console.log(`[Dictionary.KanjiData] Found "${word}": ${firstMeaning}`);
     return {
       meaning: firstMeaning,
       reading: word,
@@ -113,11 +120,16 @@ export class JishoApiDictionary implements Dictionary {
   }
 
   async lookup(word: string): Promise<WordLookupResult | null> {
-    if (!this.initialized) return null;
+    if (!this.initialized) {
+      console.log(`[Dictionary.Jisho] Not initialized, returning null for "${word}"`);
+      return null;
+    }
 
     // Check cache first
     if (this.cache.has(word)) {
-      return this.cache.get(word) || null;
+      const cached = this.cache.get(word);
+      console.log(`[Dictionary.Jisho] Cache hit for "${word}": ${cached?.meaning || 'null'}`);
+      return cached || null;
     }
 
     // Queue the request
@@ -139,13 +151,16 @@ export class JishoApiDictionary implements Dictionary {
                 meanings,
                 reading: word,
               };
+              console.log(`[Dictionary.Jisho] Found "${word}": ${meanings[0]}`);
             }
+          } else {
+            console.log(`[Dictionary.Jisho] No results from Jisho API for "${word}"`);
           }
 
           this.cache.set(word, lookupResult);
           resolve(lookupResult);
         } catch (e) {
-          console.error("[Dictionary] Jisho lookup error:", (e as any).message);
+          console.error("[Dictionary.Jisho] Lookup error for", word, ":", (e as any).message);
           this.cache.set(word, null);
           resolve(null);
         } finally {


### PR DESCRIPTION
## Summary
This PR enhances the dictionary lookup system with comprehensive debug logging and improves the fallback mechanism for word lookups. The changes make it easier to diagnose dictionary lookup issues while refining how the system handles pure hiragana words.

## Key Changes
- **Debug Logging**: Added `console.log` statements throughout `KanjiDataDictionary` and `JishoApiDictionary` to track:
  - When searchWords function is unavailable
  - When no entries are found for a word
  - Successful lookups with their meanings
  - Cache hits in the Jisho API dictionary
  - API errors with more context (word being looked up)

- **Improved Fallback Logic**: Modified `DictionaryManager.initialize()` to fall through from jmdict to Jisho API when jmdict initialization fails, and updated the condition to attempt Jisho initialization for both "jisho" and "jmdict" primary dictionary settings

- **Enhanced Pure Hiragana Handling**: Changed the logic in `processText()` to:
  - Always attempt dictionary lookup for pure hiragana words (not just when meaning is "Unknown")
  - Updated comments to clarify that dictionary lookups are tried first for hiragana-only words
  - Improved fallback comment to reference the dictionary lookup attempt

- **Better Error Messages**: Updated error logging in Jisho API to include the word being looked up for better debugging context

## Implementation Details
The logging follows a consistent format `[Dictionary.SourceName]` to make it easy to identify which dictionary component is reporting. Cache hits and successful lookups now log the actual meaning found, helping diagnose why certain words may or may not be resolving correctly.

https://claude.ai/code/session_01FeoP4pcwKyQCB2GiiSrUEG