### PR TITLE
Refactor story tokenization to use server-side processing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -214,6 +214,99 @@ async function processText(text: string) {
   return results;
 }
 
+async function processStoryText(text: string) {
+  if (!tokenizer) throw new Error("Tokenizer not ready");
+  const segments = await tokenizer.segment(text);
+
+  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
+  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+  // Find positions of each segment in the original text
+  const tokens: any[] = [];
+  let searchStart = 0;
+
+  for (const segment of segments) {
+    const segmentIndex = text.indexOf(segment, searchStart);
+    if (segmentIndex === -1) {
+      console.warn(`[API] Could not find segment "${segment}" in text starting from position ${searchStart}`);
+      continue;
+    }
+
+    const isVocabWord = !(segment.trim() === '' || isPunctuation(segment) || isSingleKana(segment));
+
+    tokens.push({
+      surface: segment,
+      startIndex: segmentIndex,
+      endIndex: segmentIndex + segment.length,
+      isVocabWord,
+    });
+
+    searchStart = segmentIndex + segment.length;
+  }
+
+  // Look up vocab words
+  const vocabTokens = tokens.filter(t => t.isVocabWord);
+  const tokenMap = new Map<string, any>();
+
+  for (const token of vocabTokens) {
+    if (tokenMap.has(token.surface)) continue;
+
+    const entries = getCachedDictionaryEntries(token.surface);
+    const { variant, entry } = findBestVariant(token.surface, entries);
+
+    let meaning = "Unknown meaning";
+    let meanings: string[] | undefined = undefined;
+    let reading = token.surface;
+
+    if (entry && variant) {
+      reading = variant.pronounced || token.surface;
+      meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
+    }
+
+    const isPureHiragana = /^[ぁ-ん]+$/.test(token.surface);
+    if (isPureHiragana && dictionary) {
+      const dictResult = await dictionary.lookup(token.surface);
+      if (dictResult) {
+        meaning = dictResult.meaning;
+        if (dictResult.meanings) {
+          meanings = dictResult.meanings;
+        }
+      }
+    }
+
+    if (meaning === "Unknown meaning" && isPureHiragana) {
+      meaning = "Kana particle / expression";
+    }
+
+    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(token.surface, variant);
+
+    tokenMap.set(token.surface, {
+      word: token.surface,
+      reading,
+      meaning,
+      jlpt,
+      joyo,
+      score,
+      breakdown,
+      meanings,
+    });
+  }
+
+  // Enrich tokens with word info
+  const enrichedTokens = tokens.map(token => {
+    if (token.isVocabWord && tokenMap.has(token.surface)) {
+      return {
+        ...token,
+        wordInfo: tokenMap.get(token.surface),
+      };
+    }
+    return token;
+  });
+
+  return enrichedTokens;
+}
+
 async function startServer() {
   // Wait for tokenizer and dictionary to be ready before starting server
   await tokenizerReady;
@@ -292,6 +385,30 @@ async function startServer() {
 
     console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words`);
     res.json(results);
+  });
+
+  app.post("/api/process-story", async (req, res) => {
+    const start = Date.now();
+    try {
+      const { text } = req.body;
+      if (!text) {
+        return res.status(400).json({ error: "No text provided" });
+      }
+      if (typeof text !== "string" || text.length > MAX_TEXT_LENGTH) {
+        return res.status(400).json({ error: `Text exceeds the ${MAX_TEXT_LENGTH} character limit` });
+      }
+      if (!JAPANESE_SCRIPT.test(text)) {
+        return res.status(400).json({ error: "Text must contain Japanese characters" });
+      }
+
+      const tokens = await processStoryText(text);
+      const elapsed = Date.now() - start;
+      console.log(`[API] /api/process-story: ${tokens.length} tokens in ${elapsed}ms`);
+      res.json({ tokens });
+    } catch (e: any) {
+      console.error(`[API Error] /api/process-story failed after ${Date.now() - start}ms:`, e.message);
+      res.status(500).json({ error: e.message });
+    }
   });
 
   app.post("/api/update-words", (req, res) => {

--- a/src/components/ContentReader.tsx
+++ b/src/components/ContentReader.tsx
@@ -9,12 +9,24 @@ function getYouTubeId(url: string) {
   return (match && match[2].length === 11) ? match[2] : null;
 }
 
-const segmenter = new Intl.Segmenter('ja-JP', { granularity: 'word' });
+interface Token {
+  surface: string;
+  startIndex: number;
+  endIndex: number;
+  isVocabWord: boolean;
+  wordInfo?: any;
+}
+
+interface ParagraphTokens {
+  text: string;
+  tokens: Token[];
+}
 
 export function ContentReader({ content, vocab, onBack }: { content: Content; vocab?: WordInfo[]; onBack: () => void }) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [showFurigana, setShowFurigana] = useState(true);
   const [showHoverDefs, setShowHoverDefs] = useState(true);
+  const [paragraphs, setParagraphs] = useState<ParagraphTokens[]>([]);
   const audioRef = useRef<HTMLAudioElement>(null);
 
   useEffect(() => {
@@ -27,58 +39,123 @@ export function ContentReader({ content, vocab, onBack }: { content: Content; vo
     }
   }, [isPlaying]);
 
-  // We can format the story text to be split by paragraphs
-  const paragraphs = content.text.split('\n').filter(p => p.trim() !== '');
+  // Process story text with API to get tokenized content
+  useEffect(() => {
+    const processStory = async () => {
+      try {
+        const response = await fetch('/api/process-story', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: content.text }),
+        });
 
-  const vocabMap = useMemo(() => {
-    const map = new Map<string, WordInfo>();
-    if (vocab) {
-      for (const w of vocab) {
-        map.set(w.word, w);
+        if (!response.ok) throw new Error('Failed to process story');
+        const data = await response.json();
+
+        // Group tokens by paragraph
+        const textLines = content.text.split('\n');
+        let currentPos = 0;
+        const paragraphTokens: ParagraphTokens[] = [];
+
+        for (const line of textLines) {
+          if (line.trim() === '') {
+            currentPos += line.length + 1; // +1 for newline
+            continue;
+          }
+
+          const lineStart = currentPos;
+          const lineEnd = currentPos + line.length;
+
+          // Filter tokens that belong to this paragraph
+          const lineTokens = data.tokens.filter((t: Token) =>
+            t.startIndex >= lineStart && t.endIndex <= lineEnd
+          );
+
+          paragraphTokens.push({
+            text: line,
+            tokens: lineTokens,
+          });
+
+          currentPos = lineEnd + 1; // +1 for newline
+        }
+
+        setParagraphs(paragraphTokens);
+      } catch (e) {
+        console.error('Failed to process story:', e);
+        // Fallback: create empty token arrays for each paragraph
+        const textLines = content.text.split('\n').filter(p => p.trim() !== '');
+        setParagraphs(textLines.map(text => ({ text, tokens: [] })));
       }
-    }
-    return map;
-  }, [vocab]);
+    };
 
-  const renderParagraph = (p: string) => {
-    if (!showFurigana && !showHoverDefs) return p;
-    const segments = Array.from(segmenter.segment(p)).map(s => s.segment);
-    return segments.map((seg: string, i: number) => {
-      const info = vocabMap.get(seg);
-      if (!info) return <span key={i}>{seg}</span>;
+    processStory();
+  }, [content.text]);
 
-      const hasFurigana = showFurigana && info.reading && info.reading !== seg && /[\u4e00-\u9faf]/.test(seg);
-      const inner = hasFurigana ? (
-        <ruby className="leading-loose">
-          {seg}
-          <rt className="text-xs text-gray-500 font-medium select-none">{info.reading}</rt>
-        </ruby>
-      ) : (
-        <span>{seg}</span>
-      );
+  const renderParagraph = (paragraphData: ParagraphTokens) => {
+    const { text, tokens } = paragraphData;
+    if (!showFurigana && !showHoverDefs) return text;
 
-      if (showHoverDefs) {
-        return (
-          <span key={i} className="relative group cursor-pointer inline-block mx-0.5 border-b border-dashed border-gray-300 hover:border-indigo-500 transition-colors">
-            {inner}
-            <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max max-w-[200px] sm:max-w-xs bg-gray-900 border border-gray-700 text-white p-3 rounded-xl shadow-xl opacity-0 group-hover:opacity-100 transition-opacity z-50 pointer-events-none text-left">
-              <div className="flex flex-col gap-1">
-                <span className="text-xs text-gray-400 font-medium">{info.reading}</span>
-                <span className="font-bold text-base">{info.word}</span>
-                <span className="text-sm border-t border-gray-700 pt-1 mt-1 text-gray-200">{info.meaning}</span>
-                <div className="flex gap-2 mt-1 text-xs text-gray-400 font-medium">
-                  {info.jlpt > 0 && <span>N{info.jlpt}</span>}
-                  <span>Score: {info.score}</span>
-                </div>
-              </div>
-              <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-x-6 border-x-transparent border-t-6 border-t-gray-900" />
-            </span>
-          </span>
+    const elements: React.ReactNode[] = [];
+    let lastEnd = 0;
+
+    // Sort tokens by startIndex
+    const sortedTokens = [...tokens].sort((a, b) => a.startIndex - b.startIndex);
+
+    for (const token of sortedTokens) {
+      const paraStart = text.indexOf(token.surface, lastEnd);
+      if (paraStart === -1) continue;
+
+      // Add text before this token
+      if (paraStart > lastEnd) {
+        elements.push(<span key={`text-${lastEnd}`}>{text.substring(lastEnd, paraStart)}</span>);
+      }
+
+      if (token.isVocabWord && token.wordInfo) {
+        const info = token.wordInfo;
+        const hasFurigana = showFurigana && info.reading && info.reading !== token.surface && /[\u4e00-\u9faf]/.test(token.surface);
+        const inner = hasFurigana ? (
+          <ruby className="leading-loose">
+            {token.surface}
+            <rt className="text-xs text-gray-500 font-medium select-none">{info.reading}</rt>
+          </ruby>
+        ) : (
+          <span>{token.surface}</span>
         );
+
+        if (showHoverDefs) {
+          elements.push(
+            <span key={`word-${token.startIndex}`} className="relative group cursor-pointer inline-block mx-0.5 border-b border-dashed border-gray-300 hover:border-indigo-500 transition-colors">
+              {inner}
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max max-w-[200px] sm:max-w-xs bg-gray-900 border border-gray-700 text-white p-3 rounded-xl shadow-xl opacity-0 group-hover:opacity-100 transition-opacity z-50 pointer-events-none text-left">
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-gray-400 font-medium">{info.reading}</span>
+                  <span className="font-bold text-base">{info.word}</span>
+                  <span className="text-sm border-t border-gray-700 pt-1 mt-1 text-gray-200">{info.meaning}</span>
+                  <div className="flex gap-2 mt-1 text-xs text-gray-400 font-medium">
+                    {info.jlpt > 0 && <span>N{info.jlpt}</span>}
+                    <span>Score: {info.score}</span>
+                  </div>
+                </div>
+                <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-x-6 border-x-transparent border-t-6 border-t-gray-900" />
+              </span>
+            </span>
+          );
+        } else {
+          elements.push(<span key={`word-${token.startIndex}`}>{inner}</span>);
+        }
+      } else {
+        elements.push(<span key={`token-${token.startIndex}`}>{token.surface}</span>);
       }
 
-      return <span key={i}>{inner}</span>;
-    });
+      lastEnd = paraStart + token.surface.length;
+    }
+
+    // Add remaining text
+    if (lastEnd < text.length) {
+      elements.push(<span key={`text-end`}>{text.substring(lastEnd)}</span>);
+    }
+
+    return elements;
   };
 
   return (


### PR DESCRIPTION
## Summary
Migrated story text tokenization from client-side (using `Intl.Segmenter`) to server-side processing. This enables richer token metadata and vocabulary matching at the API level, improving performance and maintainability.

## Key Changes

- **Server-side tokenization**: Added `/api/process-story` endpoint that tokenizes Japanese text and enriches tokens with vocabulary information (readings, meanings, JLPT levels, scores)
- **Token enrichment**: Tokens now include `isVocabWord` flag and optional `wordInfo` object with complete dictionary data, eliminating the need for client-side vocab lookups
- **Paragraph-based processing**: Refactored `ContentReader` to fetch and organize tokens by paragraph, maintaining position tracking across the full text
- **Removed client-side segmentation**: Eliminated `Intl.Segmenter` and `vocabMap` in favor of server-provided token data
- **Improved rendering**: Updated `renderParagraph` to work with pre-tokenized data, simplifying the rendering logic and reducing redundant lookups

## Implementation Details

- Token positions (`startIndex`, `endIndex`) are tracked relative to the full text, then filtered per paragraph
- Fallback behavior: If server processing fails, paragraphs render with empty token arrays (graceful degradation)
- Vocabulary matching now happens server-side using existing dictionary lookup infrastructure, reducing client-side complexity
- Token filtering excludes punctuation, particles, and whitespace using the same logic as the existing `processText` function

https://claude.ai/code/session_01325zByvRNwVRizjUcAwpDA