### PR TITLE
Add Jisho API caching and optimize batch text processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 .env*
 !.env.example
 .word-cache.json
+.jisho-cache.json
 jmdict-all-3.6.2.json
 jmdict-db/
 *.dic

--- a/server.ts
+++ b/server.ts
@@ -134,7 +134,7 @@ const dictionaryReady = (async () => {
 })();
 
 
-async function processText(text: string) {
+async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
   const tokens = await tokenizer.segment(text);
 
@@ -198,7 +198,97 @@ async function processText(text: string) {
     const isKanaOnly = isPureHiragana || isPureKatakana;
 
     if (isKanaOnly && dictionary) {
-      const dictResult = await dictionary.lookup(wordStr);
+      // Use pre-looked-up cache if available (from batch concurrent lookup)
+      const dictResult = kanaLookupCache?.get(wordStr) ?? await dictionary.lookup(wordStr);
+      if (dictResult) {
+        meaning = dictResult.meaning;
+        if (dictResult.meanings) {
+          meanings = dictResult.meanings;
+        }
+      }
+    }
+
+    // Fallback for pure hiragana particles if still no result from dictionary
+    if (meaning === "Unknown meaning" && isPureHiragana) {
+      meaning = "Kana particle / expression";
+    }
+
+    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
+    const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
+    const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
+    if (meanings) {
+      wordData.meanings = meanings;
+    }
+    results.push(wordData);
+  }
+
+  console.log(`[API] Cache stats: ${cacheHits} hits, ${cacheMisses} misses (${Math.round(cacheHits / (cacheHits + cacheMisses) * 100)}% hit rate)`);
+
+  return results;
+}
+
+async function processTextWithTokens(text: string, tokens: any[], kanaLookupCache: Map<string, any>) {
+  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
+  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+  // Count how many times each word appears (for frequencyInContent)
+  const baseFormCounts = new Map<string, number>();
+  const validWords = new Map<string, string>(); // Map surface form to baseForm for lookup
+
+  for (const token of tokens) {
+    const surface = token.surface;
+    if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+
+    if (!isSingleKana(surface)) {
+      validWords.set(surface, token.baseForm);
+      baseFormCounts.set(surface, (baseFormCounts.get(surface) ?? 0) + 1);
+    }
+  }
+
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  const results = [];
+  for (const [wordStr, baseForm] of validWords) {
+    const start = Date.now();
+    // Try to look up using baseForm first (for conjugated verbs), then fall back to wordStr
+    const cacheHadBase = wordsCache.has(baseForm);
+    const cacheHadSurface = wordsCache.has(wordStr);
+    let entries = cacheHadBase ? wordsCache.get(baseForm)! : getCachedDictionaryEntries(baseForm);
+
+    // If baseForm lookup failed, try the surface form
+    if (entries.length === 0 && baseForm !== wordStr) {
+      entries = cacheHadSurface ? wordsCache.get(wordStr)! : getCachedDictionaryEntries(wordStr);
+    }
+
+    const lookupTime = Date.now() - start;
+
+    if (cacheHadBase || cacheHadSurface) cacheHits++;
+    else cacheMisses++;
+
+    if (lookupTime > 250) {
+      console.log(`[API] Slow lookup: "${wordStr}" took ${lookupTime}ms`);
+    }
+
+    const { variant, entry } = findBestVariant(baseForm, entries);
+
+    let meaning = "Unknown meaning";
+    let meanings: string[] | undefined = undefined;
+    let reading = wordStr;
+
+    if (entry && variant) {
+      reading = variant.pronounced || wordStr;
+      meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
+    }
+
+    // Use dictionary (Jisho API or jmdict) for pure hiragana or katakana words
+    const isPureHiragana = /^[ぁ-ん]+$/.test(wordStr);
+    const isPureKatakana = /^[ァ-ヴー]+$/.test(wordStr);
+    const isKanaOnly = isPureHiragana || isPureKatakana;
+
+    if (isKanaOnly) {
+      // Use pre-looked-up cache (all kana words looked up concurrently before)
+      const dictResult = kanaLookupCache.get(wordStr);
       if (dictResult) {
         meaning = dictResult.meaning;
         if (dictResult.meanings) {
@@ -385,21 +475,81 @@ async function startServer() {
     }
 
     console.log(`[API] /api/batch-extract: Processing ${texts.length} items (cache: ${wordsCache.size} words)`);
-    const results = await Promise.all(texts.map(async (item: any) => {
-      const { id, text } = item;
-      if (!text || typeof text !== "string") return { id, error: "No text" };
 
-      const start = Date.now();
-      try {
-        const words = await processText(text);
-        const elapsed = Date.now() - start;
-        console.log(`[API] batch-extract[${id}]: ${words.length} words in ${elapsed}ms`);
-        return { id, words, elapsed };
-      } catch (e: any) {
-        console.error(`[API] batch-extract[${id}]: Error:`, e.message);
-        return { id, error: e.message };
+    // Sort by text length (shorter first) for faster initial cache warmup
+    const sortedTexts = [...texts].sort((a, b) => (a.text?.length ?? 0) - (b.text?.length ?? 0));
+
+    // Tokenize all texts concurrently upfront
+    const tokenizedBatch = await Promise.all(
+      sortedTexts.map(async (item: any) => {
+        if (!item.text || typeof item.text !== "string") return { ...item, tokens: null };
+        try {
+          const tokens = await tokenizer!.segment(item.text);
+          return { ...item, tokens };
+        } catch (e) {
+          return { ...item, tokens: null };
+        }
+      })
+    );
+
+    // Collect unique kana-only words from all texts
+    const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
+    const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+    const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+    const uniqueKanaWords = new Set<string>();
+    for (const item of tokenizedBatch) {
+      if (!item.tokens) continue;
+      for (const token of item.tokens) {
+        const surface = token.surface;
+        if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+
+        const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
+        const isPureKatakana = /^[ァ-ヴー]+$/.test(surface);
+        if (isPureHiragana || isPureKatakana) {
+          uniqueKanaWords.add(surface);
+        }
       }
-    }));
+    }
+
+    // Look up all kana words concurrently
+    console.log(`[API] /api/batch-extract: Looking up ${uniqueKanaWords.size} unique kana words concurrently`);
+    const kanaLookupCache = new Map<string, any>();
+    if (dictionary && uniqueKanaWords.size > 0) {
+      const lookupPromises = Array.from(uniqueKanaWords).map(async (word) => {
+        try {
+          const result = await dictionary.lookup(word);
+          return { word, result };
+        } catch (e) {
+          return { word, result: null };
+        }
+      });
+      const lookupResults = await Promise.all(lookupPromises);
+      for (const { word, result } of lookupResults) {
+        kanaLookupCache.set(word, result);
+      }
+    }
+
+    // Process texts with pre-looked-up kana cache
+    const results = await Promise.all(
+      tokenizedBatch.map(async (item: any) => {
+        const { id, text, tokens } = item;
+        if (!text || typeof text !== "string") return { id, error: "No text" };
+        if (!tokens) return { id, error: "Tokenization failed" };
+
+        const start = Date.now();
+        try {
+          // Re-inject tokens to avoid re-tokenizing
+          const words = await processTextWithTokens(text, tokens, kanaLookupCache);
+          const elapsed = Date.now() - start;
+          console.log(`[API] batch-extract[${id}]: ${words.length} words in ${elapsed}ms`);
+          return { id, words, elapsed };
+        } catch (e: any) {
+          console.error(`[API] batch-extract[${id}]: Error:`, e.message);
+          return { id, error: e.message };
+        }
+      })
+    );
 
     console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words`);
     res.json(results);

--- a/server.ts
+++ b/server.ts
@@ -522,12 +522,14 @@ async function startServer() {
       return res.status(400).json({ error: "texts must be an array" });
     }
 
+    const batchStart = Date.now();
     console.log(`[API] /api/batch-extract: Processing ${texts.length} items (cache: ${wordsCache.size} words)`);
 
     // Sort by text length (shorter first) for faster initial cache warmup
     const sortedTexts = [...texts].sort((a, b) => (a.text?.length ?? 0) - (b.text?.length ?? 0));
 
     // Tokenize all texts concurrently upfront
+    const tokenStart = Date.now();
     const tokenizedBatch = await Promise.all(
       sortedTexts.map(async (item: any) => {
         if (!item.text || typeof item.text !== "string") return { ...item, tokens: null };
@@ -539,6 +541,8 @@ async function startServer() {
         }
       })
     );
+    const tokenTime = Date.now() - tokenStart;
+    console.log(`[API] /api/batch-extract: Tokenization complete (${tokenTime}ms)`);
 
     // Collect unique kana-only words from all texts
     const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
@@ -561,6 +565,7 @@ async function startServer() {
     }
 
     // Look up all kana words concurrently
+    const lookupStart = Date.now();
     console.log(`[API] /api/batch-extract: Looking up ${uniqueKanaWords.size} unique kana words concurrently`);
     const kanaLookupCache = new Map<string, any>();
     if (dictionary && uniqueKanaWords.size > 0) {
@@ -577,8 +582,12 @@ async function startServer() {
         kanaLookupCache.set(word, result);
       }
     }
+    const lookupTime = Date.now() - lookupStart;
+    const foundCount = Array.from(kanaLookupCache.values()).filter(v => v !== null).length;
+    console.log(`[API] /api/batch-extract: Kana lookup complete (${lookupTime}ms, ${foundCount}/${uniqueKanaWords.size} found)`);
 
     // Process texts with pre-looked-up kana cache
+    const processStart = Date.now();
     const results = await Promise.all(
       tokenizedBatch.map(async (item: any) => {
         const { id, text, tokens } = item;
@@ -598,8 +607,11 @@ async function startServer() {
         }
       })
     );
+    const processTime = Date.now() - processStart;
+    const totalTime = Date.now() - batchStart;
 
-    console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words`);
+    console.log(`[API] /api/batch-extract: Text processing complete (${processTime}ms)`);
+    console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words (total: ${totalTime}ms)`);
     res.json(results);
   });
 
@@ -665,6 +677,36 @@ async function startServer() {
     'Authorization': `Bearer ${token}`,
     'Wanikani-Revision': '20170710',
     'Content-Type': 'application/json',
+  });
+
+  app.post("/api/clear-cache", (req, res) => {
+    const wordCacheSize = wordsCache.size;
+    const jishoCacheSize = jishoCache.size;
+
+    wordsCache.clear();
+    jishoCache.clear();
+    jishoCacheNeedsSave = true;
+    markCacheAsDirty();
+
+    console.log(`[API] /api/clear-cache: Cleared ${wordCacheSize} words and ${jishoCacheSize} Jisho entries`);
+
+    // Delete cache files
+    try {
+      if (fs.existsSync(CACHE_FILE)) {
+        fs.unlinkSync(CACHE_FILE);
+      }
+      if (fs.existsSync(JISHO_CACHE_FILE)) {
+        fs.unlinkSync(JISHO_CACHE_FILE);
+      }
+      console.log(`[API] /api/clear-cache: Deleted cache files`);
+    } catch (e) {
+      console.error('[API] /api/clear-cache: Error deleting files:', (e as any).message);
+    }
+
+    res.json({
+      cleared: true,
+      message: `Cleared ${wordCacheSize} words and ${jishoCacheSize} Jisho entries`
+    });
   });
 
   app.post("/api/wanikani/validate", async (req, res) => {

--- a/server.ts
+++ b/server.ts
@@ -26,6 +26,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const CACHE_FILE = path.join(__dirname, '.word-cache.json');
+const JISHO_CACHE_FILE = path.join(__dirname, '.jisho-cache.json');
+let jishoCache = new Map<string, any>();
+let jishoCacheNeedsSave = false;
 
 // Extract jmdict if needed
 async function ensureJmdictExtracted() {
@@ -75,6 +78,25 @@ function loadCacheFromDisk() {
   }
 }
 
+// Load Jisho API cache from disk
+function loadJishoCacheFromDisk() {
+  try {
+    if (fs.existsSync(JISHO_CACHE_FILE)) {
+      const data = JSON.parse(fs.readFileSync(JISHO_CACHE_FILE, 'utf-8'));
+      if (data && typeof data === 'object') {
+        let count = 0;
+        for (const [key, value] of Object.entries(data)) {
+          jishoCache.set(key, value);
+          count++;
+        }
+        console.log(`[Server] Loaded ${count} Jisho API entries from cache file`);
+      }
+    }
+  } catch (e) {
+    console.error('[Server] Failed to load Jisho cache from disk:', (e as any).message);
+  }
+}
+
 // Save cache to disk
 function saveCacheToDisk() {
   try {
@@ -89,6 +111,23 @@ function saveCacheToDisk() {
     console.log(`[Server] Saved ${wordsCache.size} words to cache file`);
   } catch (e) {
     console.error('[Server] Failed to save cache to disk:', (e as any).message);
+  }
+}
+
+// Save Jisho API cache to disk
+function saveJishoCacheToDisk() {
+  try {
+    if (!jishoCacheNeedsSave) return;
+
+    const obj: Record<string, any> = {};
+    for (const [key, value] of jishoCache.entries()) {
+      obj[key] = value;
+    }
+    fs.writeFileSync(JISHO_CACHE_FILE, JSON.stringify(obj), 'utf-8');
+    jishoCacheNeedsSave = false;
+    console.log(`[Server] Saved ${jishoCache.size} Jisho API entries to cache file`);
+  } catch (e) {
+    console.error('[Server] Failed to save Jisho cache to disk:', (e as any).message);
   }
 }
 
@@ -118,17 +157,25 @@ const dictionaryReady = (async () => {
   // Ensure jmdict extraction is complete before checking for the file
   await jmdictReady;
 
+  // Load Jisho cache before initializing dictionary
+  loadJishoCacheFromDisk();
+
   dictionary = new DictionaryManager();
   const jmdictPath = path.join(__dirname, 'jmdict-db');
   const jmdictFile = path.join(__dirname, 'jmdict-all-3.6.2.json');
   const jmdictExists = fs.existsSync(jmdictFile);
 
+  const onJishoCacheUpdate = (cache: Map<string, any>) => {
+    jishoCache = cache;
+    jishoCacheNeedsSave = true;
+  };
+
   if (jmdictExists) {
     console.log('[Dictionary] jmdict file found, attempting to initialize');
-    await dictionary.initialize('jmdict', jmdictPath, jmdictFile);
+    await dictionary.initialize('jmdict', jmdictPath, jmdictFile, jishoCache, onJishoCacheUpdate);
   } else {
     console.log('[Dictionary] jmdict file not found, using Jisho API');
-    await dictionary.initialize('jisho');
+    await dictionary.initialize('jisho', undefined, undefined, jishoCache, onJishoCacheUpdate);
   }
   console.log('[Dictionary] Initialization complete');
 })();
@@ -428,9 +475,10 @@ async function startServer() {
 
   app.use(express.json());
 
-  // Periodically save cache to disk (every 30 seconds if changed)
+  // Periodically save caches to disk (every 30 seconds if changed)
   setInterval(() => {
     saveCacheToDisk();
+    saveJishoCacheToDisk();
   }, 30000);
 
   app.use((req, _res, next) => {
@@ -714,16 +762,18 @@ async function startServer() {
     console.log(`Server running on http://localhost:${PORT}`);
   });
 
-  // Save cache on shutdown
+  // Save caches on shutdown
   process.on('SIGINT', () => {
-    console.log('\n[Server] Shutting down, saving cache...');
+    console.log('\n[Server] Shutting down, saving caches...');
     saveCacheToDisk();
+    saveJishoCacheToDisk();
     process.exit(0);
   });
 
   process.on('SIGTERM', () => {
-    console.log('[Server] Terminating, saving cache...');
+    console.log('[Server] Terminating, saving caches...');
     saveCacheToDisk();
+    saveJishoCacheToDisk();
     process.exit(0);
   });
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Key, RefreshCw, CheckCircle, XCircle, Loader2, AlertCircle, Trash2 } from 'lucide-react';
+import { Key, RefreshCw, CheckCircle, XCircle, Loader2, AlertCircle, Trash2, Zap } from 'lucide-react';
 import { WK_STAGE_NAMES, loadCachedWaniKaniData } from '../lib/wanikani';
+import { clearServerCache } from '../lib/api';
 
 interface WaniKaniUser {
   username: string;
@@ -9,6 +10,7 @@ interface WaniKaniUser {
 
 type TokenStatus = 'idle' | 'testing' | 'valid' | 'invalid';
 type SyncStatus = 'idle' | 'syncing' | 'done' | 'error';
+type ClearCacheStatus = 'idle' | 'clearing' | 'done' | 'error';
 
 export function SettingsPage({ onWaniKaniSync }: { onWaniKaniSync?: () => void }) {
   const [token, setToken] = useState('');
@@ -16,6 +18,7 @@ export function SettingsPage({ onWaniKaniSync }: { onWaniKaniSync?: () => void }
   const [savedUser, setSavedUser] = useState<WaniKaniUser | null>(null);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
   const [syncInfo, setSyncInfo] = useState<{ kanjiCount: number; syncedAt: number } | null>(null);
+  const [clearCacheStatus, setClearCacheStatus] = useState<ClearCacheStatus>('idle');
 
   useEffect(() => {
     const storedToken = localStorage.getItem('waniKaniToken');
@@ -87,6 +90,18 @@ export function SettingsPage({ onWaniKaniSync }: { onWaniKaniSync?: () => void }
     setTokenStatus('idle');
     setSyncStatus('idle');
     onWaniKaniSync?.();
+  };
+
+  const handleClearServerCache = async () => {
+    setClearCacheStatus('clearing');
+    try {
+      await clearServerCache();
+      setClearCacheStatus('done');
+      setTimeout(() => setClearCacheStatus('idle'), 3000);
+    } catch {
+      setClearCacheStatus('error');
+      setTimeout(() => setClearCacheStatus('idle'), 3000);
+    }
   };
 
   const hasValidToken = tokenStatus === 'valid' || (savedUser !== null && tokenStatus === 'idle');
@@ -227,6 +242,48 @@ export function SettingsPage({ onWaniKaniSync }: { onWaniKaniSync?: () => void }
                   Remove WaniKani integration
                 </button>
               </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Server Cache Management */}
+      <div className="bg-white rounded-3xl border border-gray-100 shadow-sm overflow-hidden">
+        <div className="px-8 py-6 border-b border-gray-100 flex items-center gap-3">
+          <div className="bg-amber-50 p-2 rounded-xl">
+            <Zap className="w-5 h-5 text-amber-600" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-gray-900">Cache Management</h3>
+            <p className="text-xs text-gray-500 mt-0.5">Clear dictionary and definition caches</p>
+          </div>
+        </div>
+
+        <div className="px-8 py-6 space-y-4">
+          <p className="text-sm text-gray-600">
+            Clear server-side caches to force fresh dictionary lookups. Use this when testing or troubleshooting.
+          </p>
+          <button
+            onClick={handleClearServerCache}
+            disabled={clearCacheStatus === 'clearing'}
+            className="flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-700 text-sm font-medium rounded-xl hover:bg-amber-100 border border-amber-200 disabled:opacity-50 transition-colors w-full justify-center"
+          >
+            {clearCacheStatus === 'clearing' ? (
+              <><Loader2 className="w-4 h-4 animate-spin" /> Clearing...</>
+            ) : (
+              <><Trash2 className="w-4 h-4" /> Clear Server Cache</>
+            )}
+          </button>
+          {clearCacheStatus === 'done' && (
+            <div className="flex items-center gap-2 text-green-700 text-sm bg-green-50 border border-green-100 rounded-lg px-3 py-2">
+              <CheckCircle className="w-4 h-4 shrink-0" />
+              Cache cleared! Next lookup will re-fetch from Jisho API.
+            </div>
+          )}
+          {clearCacheStatus === 'error' && (
+            <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              Failed to clear cache. Try again.
             </div>
           )}
         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,22 @@
 import { WordInfo } from "../types";
 
-export async function extractVocabulary(text: string, onProgress?: (status: string) => void): Promise<WordInfo[]> {
+export async function clearServerCache(): Promise<void> {
+  const res = await fetch("/api/clear-cache", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" }
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body.error ?? `HTTP ${res.status}`;
+    console.error(`[API Error] /api/clear-cache failed: ${message}`);
+    throw new Error(message);
+  }
+
+  const result = await res.json();
+  console.log(`[API] Cache cleared: ${result.message}`);
+}
+
   const start = Date.now();
   const charCount = text.length;
 

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -73,6 +73,17 @@ export class JishoApiDictionary implements Dictionary {
   private requestQueue: Array<() => Promise<void>> = [];
   private activeRequests = 0;
   private maxConcurrent = 2; // Limit to 2 concurrent requests to avoid overwhelming Jisho
+  private persistentCache: Map<string, WordLookupResult | null>;
+  private onCacheUpdate?: (cache: Map<string, WordLookupResult | null>) => void;
+
+  constructor(persistentCache?: Map<string, WordLookupResult | null>, onCacheUpdate?: (cache: Map<string, WordLookupResult | null>) => void) {
+    this.persistentCache = persistentCache || new Map();
+    this.onCacheUpdate = onCacheUpdate;
+    // Load persistent cache into memory
+    for (const [key, value] of this.persistentCache.entries()) {
+      this.cache.set(key, value);
+    }
+  }
 
   async initialize(): Promise<void> {
     try {
@@ -80,7 +91,7 @@ export class JishoApiDictionary implements Dictionary {
       const testRes = await this.fetchFromJisho("test");
       if (testRes) {
         this.initialized = true;
-        console.log("[Dictionary] Jisho API initialized (max 2 concurrent requests)");
+        console.log(`[Dictionary] Jisho API initialized (max 2 concurrent requests, ${this.cache.size} cached)`);
       }
     } catch (e) {
       console.warn("[Dictionary] Jisho API unavailable:", (e as any).message);
@@ -160,10 +171,14 @@ export class JishoApiDictionary implements Dictionary {
           }
 
           this.cache.set(word, lookupResult);
+          this.persistentCache.set(word, lookupResult);
+          this.onCacheUpdate?.(this.persistentCache);
           resolve(lookupResult);
         } catch (e) {
           console.error("[Dictionary.Jisho] Lookup error for", word, ":", (e as any).message);
           this.cache.set(word, null);
+          this.persistentCache.set(word, null);
+          this.onCacheUpdate?.(this.persistentCache);
           resolve(null);
         } finally {
           this.processQueue();
@@ -256,14 +271,16 @@ export class DictionaryManager {
   async initialize(
     usePrimary: "jmdict" | "jisho" | "kanjidata" = "jisho",
     jmdictPath?: string,
-    jmdictFile?: string
+    jmdictFile?: string,
+    jishoCache?: Map<string, WordLookupResult | null>,
+    onJishoCacheUpdate?: (cache: Map<string, WordLookupResult | null>) => void
   ): Promise<void> {
     if (usePrimary === "jmdict" && jmdictPath && jmdictFile) {
       const jmdictDict = new JmdictDictionary();
       await jmdictDict.initialize(jmdictPath, jmdictFile);
       if (jmdictDict.isInitialized()) {
         this.primary = jmdictDict;
-        this.fallback = new JishoApiDictionary();
+        this.fallback = new JishoApiDictionary(jishoCache, onJishoCacheUpdate);
         await (this.fallback as JishoApiDictionary).initialize();
         return;
       }
@@ -271,7 +288,7 @@ export class DictionaryManager {
     }
 
     if (usePrimary === "jisho" || usePrimary === "jmdict") {
-      const jishoDict = new JishoApiDictionary();
+      const jishoDict = new JishoApiDictionary(jishoCache, onJishoCacheUpdate);
       await jishoDict.initialize();
       if (jishoDict.isInitialized()) {
         this.primary = jishoDict;

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -228,16 +228,34 @@ export class JmdictDictionary implements Dictionary {
       }
       if (results.length === 0) return null;
 
-      // Find exact match or best match
-      const bestMatch = results.find(
+      // Find best match: prioritize entries with exact kana/kanji match + common words
+      let bestMatch = results.find(
         (r) =>
           r.kana.some((k: any) => k.text === word) ||
           r.kanji.some((k: any) => k.text === word)
-      ) || results[0];
+      );
 
-      // Extract all meanings (senses ordered by frequency in jmdict-simplified)
+      // If no exact match, score all results by commonness
+      if (!bestMatch) {
+        bestMatch = results.reduce((best: any, current: any) => {
+          const bestScore = this.getEntryCommonness(best);
+          const currentScore = this.getEntryCommonness(current);
+          return currentScore > bestScore ? current : best;
+        });
+      }
+
+      // Extract all meanings (prioritize more common senses)
       const meanings: string[] = [];
-      for (const sense of bestMatch.sense) {
+      const sensesWithScores = (bestMatch.sense || []).map((sense: any, idx: number) => ({
+        sense,
+        order: idx,
+        commonness: this.getSenseCommonness(sense)
+      }));
+
+      // Sort by commonness (higher first)
+      sensesWithScores.sort((a, b) => b.commonness - a.commonness);
+
+      for (const { sense } of sensesWithScores) {
         if (sense.gloss && sense.gloss.length > 0) {
           const glossTexts = (sense.gloss as any[])
             .filter((g) => g.lang === "en")
@@ -260,6 +278,52 @@ export class JmdictDictionary implements Dictionary {
       console.error("[Dictionary] JMDict lookup error:", (e as any).message);
       return null;
     }
+  }
+
+  private getEntryCommonness(entry: any): number {
+    // Score entries by how "common" they appear
+    let score = 0;
+
+    // Prefer entries with kanji (more concrete words)
+    if (entry.kanji && entry.kanji.length > 0) {
+      score += 10;
+    }
+
+    // Prefer entries with multiple kanji variants (widely used)
+    if (entry.kanji && entry.kanji.length > 1) {
+      score += 5;
+    }
+
+    // Prefer entries with multiple senses (more established)
+    if (entry.sense && entry.sense.length > 1) {
+      score += 3;
+    }
+
+    return score;
+  }
+
+  private getSenseCommonness(sense: any): number {
+    // Score senses by how "common" they are
+    let score = 0;
+
+    // Prefer senses with multiple glosses (well-established meanings)
+    if (sense.gloss && Array.isArray(sense.gloss) && sense.gloss.length > 1) {
+      score += 5;
+    }
+
+    // Penalize specialized meanings
+    const gloss = sense.gloss?.[0]?.text || '';
+    const specializedTerms = ['esp.', 'rare', 'archaic', 'obsolete', 'old', 'dated', 'specialized'];
+    if (specializedTerms.some(term => gloss.toLowerCase().includes(term))) {
+      score -= 10;
+    }
+
+    // Prefer common grammatical terms
+    if (gloss.toLowerCase().includes('copula') || gloss.toLowerCase().includes('auxiliary')) {
+      score += 3;
+    }
+
+    return score;
   }
 }
 

--- a/test-dictionaries-detailed.ts
+++ b/test-dictionaries-detailed.ts
@@ -1,0 +1,197 @@
+import { createRequire } from 'module';
+import { createTokenizer } from './src/lib/tokenizers.js';
+import { JmdictDictionary, JishoApiDictionary } from './src/lib/dictionary.js';
+
+const require = createRequire(import.meta.url);
+const kanjiData = require('kanji-data');
+
+const testText = `はじめまして。
+
+わたしのなまえはたなかです。
+
+にほんじんです。
+
+とうきょうにすんでいます。
+
+がくせいです。
+
+どうぞよろしくおねがいします。`;
+
+interface DetailedTestResult {
+  word: string;
+  jmdictAll: string[];
+  jmdictFirst: string | null;
+  jishoAll: string[];
+  jishoFirst: string | null;
+  correct: string; // What the word should mean
+}
+
+const expectedMeanings: Record<string, string> = {
+  'はじめまして': 'first time / nice to meet you',
+  'わたし': 'I / me',
+  'なまえ': 'name',
+  'たなか': 'Tanaka (name) / name',
+  'です': 'to be / copula',
+  'にほん': 'Japan',
+  'じん': 'person / people',
+  'とうきょう': 'Tokyo',
+  'すん': 'sun (unit) / live / be located',
+  'ます': 'increase / polite auxiliary',
+  'がく': 'frame / study / learning',
+  'せい': 'surname / voice / nature',
+  'どうぞ': 'please / go ahead',
+  'よろしく': 'well / sincerely / please',
+  'ねがい': 'wish / request / desire'
+};
+
+async function runTest() {
+  console.log('=== DETAILED Dictionary Accuracy Test ===\n');
+  console.log('Test text (pure hiragana):\n', testText, '\n');
+
+  // Initialize tokenizer
+  const tokenizer = await createTokenizer();
+  console.log('✓ Tokenizer ready\n');
+
+  // Initialize JMDict
+  const jmdict = new JmdictDictionary();
+  await jmdict.initialize('jmdict-db', 'jmdict-all-3.6.2.json');
+  console.log(`✓ JMDict initialized: ${jmdict.isInitialized() ? 'ready' : 'failed'}\n`);
+
+  // Initialize Jisho API
+  const jisho = new JishoApiDictionary();
+  await jisho.initialize();
+  console.log(`✓ Jisho API initialized: ${jisho.isInitialized() ? 'ready' : 'failed'}\n`);
+
+  // Tokenize text
+  const tokens = await tokenizer.segment(testText);
+
+  // Extract hiragana-only words
+  const particles = new Set(['は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ']);
+  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+  const uniqueWords = new Set<string>();
+  for (const token of tokens) {
+    const surface = token.surface;
+    if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+
+    const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
+    if (isPureHiragana) {
+      uniqueWords.add(surface);
+    }
+  }
+
+  console.log(`Found ${uniqueWords.size} unique hiragana words\n`);
+  console.log('Testing each dictionary (showing all definitions)...\n');
+
+  // Test each word
+  const results: DetailedTestResult[] = [];
+  for (const word of uniqueWords) {
+    const jmdictResult = await jmdict.lookup(word);
+    const jishoResult = await jisho.lookup(word);
+
+    const jmdictAll = jmdictResult?.meanings ? jmdictResult.meanings : [];
+    const jishoAll = jishoResult?.meanings ? jishoResult.meanings : [];
+
+    results.push({
+      word,
+      jmdictAll: jmdictAll as string[],
+      jmdictFirst: jmdictResult?.meaning || null,
+      jishoAll: jishoAll as string[],
+      jishoFirst: jishoResult?.meaning || null,
+      correct: expectedMeanings[word] || '?'
+    });
+  }
+
+  // Sort by word
+  results.sort((a, b) => a.word.localeCompare(b.word));
+
+  // Display results
+  console.log('DETAILED DEFINITION COMPARISON');
+  console.log('='.repeat(100));
+
+  for (const result of results) {
+    console.log(`\n📝 ${result.word} (should mean: ${result.correct})`);
+    console.log('-'.repeat(100));
+
+    // JMDict
+    if (result.jmdictAll.length > 0) {
+      console.log(`  JMDict (${result.jmdictAll.length} definitions):`);
+      result.jmdictAll.slice(0, 3).forEach((def, i) => {
+        const marker = i === 0 ? '→ FIRST:' : `  Alt ${i}:`;
+        console.log(`    ${marker} ${def}`);
+      });
+      if (result.jmdictAll.length > 3) {
+        console.log(`    ... and ${result.jmdictAll.length - 3} more`);
+      }
+    } else {
+      console.log(`  JMDict: ❌ NOT FOUND`);
+    }
+
+    // Jisho API
+    if (result.jishoAll.length > 0) {
+      console.log(`  Jisho API (${result.jishoAll.length} definitions):`);
+      result.jishoAll.slice(0, 3).forEach((def, i) => {
+        const marker = i === 0 ? '→ FIRST:' : `  Alt ${i}:`;
+        console.log(`    ${marker} ${def}`);
+      });
+      if (result.jishoAll.length > 3) {
+        console.log(`    ... and ${result.jishoAll.length - 3} more`);
+      }
+    } else {
+      console.log(`  Jisho API: ❌ NOT FOUND`);
+    }
+
+    // Accuracy assessment
+    const jmdictAccurate = result.jmdictAll.some(d =>
+      result.correct.toLowerCase().includes(d.toLowerCase().split('(')[0].trim()) ||
+      d.toLowerCase().includes(result.correct.toLowerCase().split('/')[0].trim())
+    );
+    const jishoAccurate = result.jishoAll.some(d =>
+      result.correct.toLowerCase().includes(d.toLowerCase().split('(')[0].trim()) ||
+      d.toLowerCase().includes(result.correct.toLowerCase().split('/')[0].trim())
+    );
+
+    if (jmdictAccurate) console.log(`  ✅ JMDict has accurate definition`);
+    else if (result.jmdictAll.length > 0) console.log(`  ⚠️  JMDict definition may be inaccurate`);
+
+    if (jishoAccurate) console.log(`  ✅ Jisho has accurate definition`);
+    else if (result.jishoAll.length > 0) console.log(`  ⚠️  Jisho definition may be inaccurate`);
+  }
+
+  // Summary
+  console.log('\n' + '='.repeat(100));
+  console.log('\n📊 SUMMARY');
+
+  const jmdictComplete = results.filter(r => r.jmdictAll.length > 0).length;
+  const jishoComplete = results.filter(r => r.jishoAll.length > 0).length;
+
+  const jmdictAccurate = results.filter(r =>
+    r.jmdictAll.some(d =>
+      r.correct.toLowerCase().includes(d.toLowerCase().split('(')[0].trim()) ||
+      d.toLowerCase().includes(r.correct.toLowerCase().split('/')[0].trim())
+    )
+  ).length;
+
+  const jishoAccurate = results.filter(r =>
+    r.jishoAll.some(d =>
+      r.correct.toLowerCase().includes(d.toLowerCase().split('(')[0].trim()) ||
+      d.toLowerCase().includes(r.correct.toLowerCase().split('/')[0].trim())
+    )
+  ).length;
+
+  console.log(`\nCoverage (finds the word):`);
+  console.log(`  JMDict: ${jmdictComplete}/${results.length} (${Math.round(jmdictComplete / results.length * 100)}%)`);
+  console.log(`  Jisho:  ${jishoComplete}/${results.length} (${Math.round(jishoComplete / results.length * 100)}%)`);
+
+  console.log(`\nAccuracy (has a correct definition in list):`);
+  console.log(`  JMDict: ${jmdictAccurate}/${results.length} (${Math.round(jmdictAccurate / results.length * 100)}%)`);
+  console.log(`  Jisho:  ${jishoAccurate}/${results.length} (${Math.round(jishoAccurate / results.length * 100)}%)`);
+
+  process.exit(0);
+}
+
+runTest().catch(e => {
+  console.error('Test failed:', e);
+  process.exit(1);
+});

--- a/test-dictionaries.ts
+++ b/test-dictionaries.ts
@@ -1,0 +1,123 @@
+import { createRequire } from 'module';
+import { createTokenizer } from './src/lib/tokenizers.js';
+import { JmdictDictionary, JishoApiDictionary } from './src/lib/dictionary.js';
+
+const require = createRequire(import.meta.url);
+const kanjiData = require('kanji-data');
+
+const testText = `はじめまして。
+
+わたしのなまえはたなかです。
+
+にほんじんです。
+
+とうきょうにすんでいます。
+
+がくせいです。
+
+どうぞよろしくおねがいします。`;
+
+interface TestResult {
+  word: string;
+  jmdict: string | null;
+  jisho: string | null;
+  found: number;
+}
+
+async function runTest() {
+  console.log('=== Dictionary Accuracy Test ===\n');
+  console.log('Test text (pure hiragana):\n', testText, '\n');
+
+  // Initialize tokenizer
+  const tokenizer = await createTokenizer();
+  console.log('✓ Tokenizer ready\n');
+
+  // Initialize JMDict
+  const jmdict = new JmdictDictionary();
+  await jmdict.initialize('jmdict-db', 'jmdict-all-3.6.2.json');
+  console.log(`✓ JMDict initialized: ${jmdict.isInitialized() ? 'ready' : 'failed'}\n`);
+
+  // Initialize Jisho API
+  const jisho = new JishoApiDictionary();
+  await jisho.initialize();
+  console.log(`✓ Jisho API initialized: ${jisho.isInitialized() ? 'ready' : 'failed'}\n`);
+
+  // Tokenize text
+  const tokens = await tokenizer.segment(testText);
+
+  // Extract hiragana-only words
+  const particles = new Set(['は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ']);
+  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+  const uniqueWords = new Set<string>();
+  for (const token of tokens) {
+    const surface = token.surface;
+    if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+
+    const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
+    if (isPureHiragana) {
+      uniqueWords.add(surface);
+    }
+  }
+
+  console.log(`Found ${uniqueWords.size} unique hiragana words\n`);
+  console.log('Testing each dictionary...\n');
+
+  // Test each word
+  const results: TestResult[] = [];
+  for (const word of uniqueWords) {
+    const jmdictResult = await jmdict.lookup(word);
+    const jishoResult = await jisho.lookup(word);
+
+    const found = (jmdictResult ? 1 : 0) + (jishoResult ? 1 : 0);
+    results.push({
+      word,
+      jmdict: jmdictResult?.meaning || null,
+      jisho: jishoResult?.meaning || null,
+      found
+    });
+  }
+
+  // Sort by found count
+  results.sort((a, b) => b.found - a.found);
+
+  // Display results
+  console.log('Word | JMDict | Jisho API | Found');
+  console.log('-'.repeat(80));
+
+  for (const result of results) {
+    const jmdictMeaning = result.jmdict || '❌';
+    const jishoMeaning = result.jisho || '❌';
+    const found = result.found === 2 ? '✅ Both' : result.found === 1 ? '⚠️  One' : '❌ None';
+
+    console.log(`${result.word.padEnd(12)} | ${jmdictMeaning.padEnd(20)} | ${jishoMeaning.padEnd(20)} | ${found}`);
+  }
+
+  // Statistics
+  console.log('\n' + '='.repeat(80));
+  const jmdictFound = results.filter(r => r.jmdict).length;
+  const jishoFound = results.filter(r => r.jisho).length;
+  const bothFound = results.filter(r => r.found === 2).length;
+  const noneFound = results.filter(r => r.found === 0).length;
+
+  console.log('\nAccuracy Statistics:');
+  console.log(`JMDict:     ${jmdictFound}/${results.length} (${Math.round(jmdictFound / results.length * 100)}%)`);
+  console.log(`Jisho API:  ${jishoFound}/${results.length} (${Math.round(jishoFound / results.length * 100)}%)`);
+  console.log(`Both found: ${bothFound}/${results.length} (${Math.round(bothFound / results.length * 100)}%)`);
+  console.log(`None found: ${noneFound}/${results.length} (${Math.round(noneFound / results.length * 100)}%)`);
+
+  if (noneFound > 0) {
+    console.log(`\nWords not found in either dictionary:`);
+    results.filter(r => r.found === 0).forEach(r => {
+      console.log(`  - ${r.word}`);
+    });
+  }
+
+  process.exit(0);
+}
+
+runTest().catch(e => {
+  console.error('Test failed:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
This PR implements persistent caching for Jisho API lookups and significantly optimizes batch text processing performance through concurrent tokenization and pre-lookup of kana-only words.

## Key Changes

### Jisho API Caching
- Added persistent cache file (`.jisho-cache.json`) for Jisho API responses to reduce redundant API calls
- Implemented `loadJishoCacheFromDisk()` and `saveJishoCacheToDisk()` functions to manage cache lifecycle
- Modified `JishoApiDictionary` to accept and update a persistent cache map
- Cache is automatically saved every 30 seconds and on server shutdown

### Batch Processing Optimization
- Refactored `/api/batch-extract` endpoint to process texts in three optimized stages:
  1. **Concurrent tokenization**: All texts tokenized upfront in parallel
  2. **Concurrent kana lookup**: All unique kana-only words looked up concurrently before processing
  3. **Parallel text processing**: Individual texts processed with pre-populated lookup cache
- Created new `processTextWithTokens()` function to reuse tokenization results and pre-looked-up definitions
- Texts are sorted by length (shorter first) for faster initial cache warmup

### Dictionary Improvements
- Enhanced `JmdictDictionary` with better entry and sense scoring:
  - Prioritizes entries with kanji and multiple variants
  - Scores senses by commonness, penalizing specialized/archaic terms
  - Improved selection of most relevant definitions
- Updated `DictionaryManager.initialize()` to accept and pass through cache callbacks

### Cache Management
- Added `/api/clear-cache` endpoint to clear both word and Jisho caches
- Added "Cache Management" section to Settings UI with clear cache button
- Cache files are properly deleted when cleared

### Testing
- Added `test-dictionaries.ts` for basic dictionary accuracy testing
- Added `test-dictionaries-detailed.ts` for detailed definition comparison between JMDict and Jisho API

## Notable Implementation Details
- Jisho API cache is passed as a `Map<string, WordLookupResult | null>` to support both successful lookups and negative caching (words not found)
- Batch processing now logs detailed timing metrics: tokenization time, lookup time, and per-item processing time
- Cache hit rate is tracked and logged for performance monitoring
- Concurrent requests to Jisho API remain limited to 2 to avoid overwhelming the service

https://claude.ai/code/session_01WSy1N8XnPumNvZxXpd5a5j