### PR TITLE
Add .js extension to content import for ES modules

### DIFF
--- a/test-all-stories.ts
+++ b/test-all-stories.ts
@@ -1,4 +1,4 @@
-import { INITIAL_CONTENT } from './src/data/content';
+import { INITIAL_CONTENT } from './src/data/content.js';
 import { createTokenizer } from './src/lib/tokenizers';
 import { DictionaryManager } from './src/lib/dictionary';
 import path from 'path';


### PR DESCRIPTION
## Summary
Updated the import statement in the test file to include the `.js` file extension, ensuring compatibility with ES module resolution.

## Changes
- Added `.js` extension to the `INITIAL_CONTENT` import path in `test-all-stories.ts`
  - Changed from: `'./src/data/content'`
  - Changed to: `'./src/data/content.js'`

## Details
This change aligns with ES module standards where explicit file extensions are required for relative imports. This is particularly important when using Node.js with ES modules or when running in strict module resolution environments.

https://claude.ai/code/session_0156SYaMJfqJgaR24D2ApNed