### PR TITLE
Add related words and improve WaniKani data handling in word details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ export default function App() {
 
   const navigateToWord = (word: string) => {
     setSelectedWord(word);
-    window.history.pushState({ type: 'word', word }, '', `/word/${encodeURIComponent(word)}`);
+    window.history.pushState({ type: 'word', word, scrollPos: window.scrollY }, '', `/word/${encodeURIComponent(word)}`);
   };
 
   const navigateBack = () => {
@@ -203,6 +203,7 @@ export default function App() {
       <WordDetailPage
         word={selectedWord}
         onBack={navigateBack}
+        allWords={Object.values(contentVocab).flat()}
       />
     );
   }

--- a/src/components/WordDetailPage.tsx
+++ b/src/components/WordDetailPage.tsx
@@ -9,16 +9,26 @@ interface WordDetailData extends WordInfo {
 
 export function WordDetailPage({
   word,
-  onBack
+  onBack,
+  allWords = []
 }: {
   word: string;
   onBack: () => void;
+  allWords?: WordInfo[];
 }) {
   const [wordData, setWordData] = useState<WordDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [wkSrsStage, setWkSrsStage] = useState<number | null>(null);
   const [relatedWords, setRelatedWords] = useState<WordInfo[]>([]);
+
+  const handleBack = () => {
+    const scrollPos = window.history.state?.scrollPos;
+    onBack();
+    if (scrollPos !== undefined) {
+      setTimeout(() => window.scrollTo(0, scrollPos), 0);
+    }
+  };
 
   useEffect(() => {
     const fetchWordData = async () => {
@@ -39,15 +49,32 @@ export function WordDetailPage({
           setWkSrsStage(stage);
         }
 
-        // Find related words by kanji (simplified approach)
-        const relatedList: WordInfo[] = [];
+        // Find related words by kanji
         const wordKanjis = new Set<string>();
         const wordRegex = /[一-龯]/g;
         const matches = word.match(wordRegex);
         if (matches) {
           matches.forEach(k => wordKanjis.add(k));
         }
-        setRelatedWords(relatedList);
+
+        const relatedList: WordInfo[] = [];
+        if (wordKanjis.size > 0) {
+          const seen = new Set<string>([word]);
+          for (const w of allWords) {
+            if (seen.has(w.word)) continue;
+            const wMatches = w.word.match(wordRegex);
+            if (wMatches) {
+              for (const k of wMatches) {
+                if (wordKanjis.has(k)) {
+                  relatedList.push(w);
+                  seen.add(w.word);
+                  break;
+                }
+              }
+            }
+          }
+        }
+        setRelatedWords(relatedList.slice(0, 10));
       } catch (e) {
         setError((e as any).message || 'Failed to load word details');
       } finally {
@@ -56,7 +83,7 @@ export function WordDetailPage({
     };
 
     fetchWordData();
-  }, [word]);
+  }, [word, allWords]);
 
   if (loading) {
     return (
@@ -64,7 +91,7 @@ export function WordDetailPage({
         <header className="bg-white/80 backdrop-blur-md sticky top-0 z-10 px-6 py-4 border-b border-gray-200">
           <div className="max-w-3xl mx-auto flex items-center">
             <button
-              onClick={onBack}
+              onClick={handleBack}
               className="flex items-center gap-2 text-gray-600 hover:text-black transition"
             >
               <ArrowLeft className="w-5 h-5" />
@@ -85,7 +112,7 @@ export function WordDetailPage({
         <header className="bg-white/80 backdrop-blur-md sticky top-0 z-10 px-6 py-4 border-b border-gray-200">
           <div className="max-w-3xl mx-auto flex items-center">
             <button
-              onClick={onBack}
+              onClick={handleBack}
               className="flex items-center gap-2 text-gray-600 hover:text-black transition"
             >
               <ArrowLeft className="w-5 h-5" />
@@ -249,6 +276,25 @@ export function WordDetailPage({
                     ))}
                   </div>
                 )}
+              </div>
+            </div>
+          )}
+
+          {/* Related Words */}
+          {relatedWords.length > 0 && (
+            <div className="space-y-3 border-t border-gray-100 pt-6">
+              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-widest">Related Words</h2>
+              <p className="text-sm text-gray-600">Words that share kanji with this word:</p>
+              <div className="flex flex-wrap gap-2">
+                {relatedWords.map((w, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => window.location.hash = `/word/${encodeURIComponent(w.word)}`}
+                    className="px-3 py-2 bg-indigo-50 border border-indigo-200 text-indigo-700 rounded-lg text-sm font-medium hover:bg-indigo-100 transition-colors"
+                  >
+                    {w.word}
+                  </button>
+                ))}
               </div>
             </div>
           )}

--- a/src/components/WordDetailPage.tsx
+++ b/src/components/WordDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { WordInfo } from '../types';
 import { ArrowLeft, Loader2 } from 'lucide-react';
-import { WK_STAGE_NAMES } from '../lib/wanikani';
+import { WK_STAGE_NAMES, getWaniKaniSrsStage, loadCachedWaniKaniData } from '../lib/wanikani';
 
 interface WordDetailData extends WordInfo {
   entry?: any;
@@ -17,6 +17,8 @@ export function WordDetailPage({
   const [wordData, setWordData] = useState<WordDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [wkSrsStage, setWkSrsStage] = useState<number | null>(null);
+  const [relatedWords, setRelatedWords] = useState<WordInfo[]>([]);
 
   useEffect(() => {
     const fetchWordData = async () => {
@@ -29,6 +31,23 @@ export function WordDetailPage({
         }
         const data = await response.json();
         setWordData(data);
+
+        // Load WaniKani data from localStorage
+        const wkCache = loadCachedWaniKaniData();
+        if (wkCache) {
+          const stage = getWaniKaniSrsStage(word, wkCache.data);
+          setWkSrsStage(stage);
+        }
+
+        // Find related words by kanji (simplified approach)
+        const relatedList: WordInfo[] = [];
+        const wordKanjis = new Set<string>();
+        const wordRegex = /[一-龯]/g;
+        const matches = word.match(wordRegex);
+        if (matches) {
+          matches.forEach(k => wordKanjis.add(k));
+        }
+        setRelatedWords(relatedList);
       } catch (e) {
         setError((e as any).message || 'Failed to load word details');
       } finally {
@@ -152,17 +171,21 @@ export function WordDetailPage({
                 </div>
               )}
 
-              {wordData.wkSrsStage !== undefined && (
-                <div className="bg-gray-50 p-4 rounded-lg">
-                  <p className="text-xs text-gray-500 font-medium mb-1">WaniKani</p>
-                  <p className="text-sm font-bold text-purple-600">
-                    Stage {wordData.wkSrsStage}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    {WK_STAGE_NAMES[wordData.wkSrsStage.toString()] || 'Unknown'}
-                  </p>
-                </div>
-              )}
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <p className="text-xs text-gray-500 font-medium mb-1">WaniKani</p>
+                {wkSrsStage !== null ? (
+                  <>
+                    <p className="text-sm font-bold text-purple-600">
+                      Stage {wkSrsStage}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      {WK_STAGE_NAMES[wkSrsStage.toString()] || 'Unknown'}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-sm font-medium text-gray-400">N/A</p>
+                )}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Enhanced the word detail page with related word suggestions and improved WaniKani SRS stage data handling by loading from cached data instead of relying on the API response.

## Key Changes
- **Related Words Feature**: Added functionality to find and display words that share kanji with the currently viewed word, limited to 10 results
- **WaniKani Data Loading**: Refactored to load WaniKani SRS stage data from localStorage cache using `loadCachedWaniKaniData()` and `getWaniKaniSrsStage()` utilities instead of relying on the word detail API response
- **Scroll Position Preservation**: Implemented scroll position tracking when navigating between words, restoring the user's scroll position when returning
- **Props Enhancement**: Added `allWords` prop to `WordDetailPage` component to enable related word matching across the vocabulary dataset
- **UI Improvements**: Updated WaniKani stage display to handle cases where data is unavailable (showing "N/A" instead of conditionally hiding the section)

## Implementation Details
- Related words are identified by extracting kanji characters from the current word and matching them against all available words
- Kanji matching uses regex pattern `/[一-龯]/g` to identify CJK unified ideographs
- Scroll position is stored in the history state and restored with a setTimeout to ensure DOM is ready
- Related words section displays up to 10 matches with clickable buttons for navigation

https://claude.ai/code/session_01G3s3RsYqR2iBeKcBWzHpLq