### PR TITLE
Add comprehensive video content catalog for Japanese learners

### DIFF
--- a/VIDEOS.md
+++ b/VIDEOS.md
@@ -1,0 +1,335 @@
+# Kotonoha Video Content & Media Catalog
+
+This document provides a comprehensive list of movies, TV shows, and animated content organized by difficulty level and learning value for Japanese learners.
+
+---
+
+## N5 Level Videos (Beginner-Friendly)
+
+*Simple dialogue, slow speech, clear pronunciation, and visual storytelling. Perfect for absolute beginners.*
+
+### Classic Anime Series (Very Simple Language)
+
+- **Anpanman** (アンパンマン) — Episodes 1-50
+  - *Format:* Anime series (15-25 min episodes)
+  - *Learning Value:* Extremely simple vocabulary, repetitive dialogue, visual cues
+  - *Content:* Adventures of a superhero with a bread head; perfect for young learners
+
+- **Doraemon** (ドラえもん) — Early episodes
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Everyday conversation, simple explanations, comedy for context
+  - *Content:* A robot cat from the future helps with daily problems
+
+- **Chi's Sweet Home** (チーズスイートホーム)
+  - *Format:* Anime series (4 min episodes)
+  - *Learning Value:* Short episodes, simple narration, pet perspective
+  - *Content:* A kitten adjusting to a new home; cuteness helps with engagement
+
+- **Crayon Shin-chan** (クレヨンしんちゃん) — Select episodes
+  - *Format:* Anime series (24-26 min episodes)
+  - *Learning Value:* Casual family dialogue, comedic context aids understanding
+  - *Content:* Family comedy; episodes have repetitive humor patterns
+
+### Studio Ghibli Films (Beginner-Friendly)
+
+- **My Neighbor Totoro** (となりのトトロ)
+  - *Format:* Feature film (88 min)
+  - *Learning Value:* Slow pacing, simple dialogue, beautiful visuals tell the story
+  - *Content:* Sisters encounter friendly forest spirits
+  - *Difficulty Note:* Perfect introduction to Ghibli; minimal dialogue-dependent plot
+
+- **Kiki's Delivery Service** (魔女の宅急便)
+  - *Format:* Feature film (103 min)
+  - *Learning Value:* Coming-of-age themes, simple daily dialogue
+  - *Content:* Young witch moving to a new city
+  - *Difficulty Note:* Clear story progression; good for following along
+
+- **Ponyo** (ポニョ)
+  - *Format:* Feature film (100 min)
+  - *Learning Value:* Simple dialogue, visual storytelling, child characters
+  - *Content:* A fish-girl and a boy's friendship
+  - *Difficulty Note:* Dreamlike quality allows for understanding gaps
+
+### NHK Educational Content
+
+- **NHK Eテレ Kids Programs**
+  - *Format:* Short TV segments (5-15 min)
+  - *Learning Value:* Designed for native Japanese children; controlled vocabulary
+  - *Content:* Educational programs with clear enunciation
+  - *Examples:* おかあさんといっしょ (With Mom), いないいないばあっ! (Peek-a-Boo)
+
+- **NHK World Easy Japanese** (やさしい日本語 - Official Learning Content)
+  - *Format:* Short lessons with video (3-5 min)
+  - *Learning Value:* Specifically designed for learners; subtitles available
+  - *Content:* Daily scenarios, cultural explanations
+
+### Ghibli Short Films
+
+- **Spirited Away** (千と千尋の神隠し) - *Note: More complex, but highly visual*
+  - *Format:* Feature film (125 min)
+  - *Learning Value:* Fantastical visuals compensate for language difficulty
+  - *Content:* Girl navigating a spirit world
+  - *Difficulty Note:* Borderline N5/N4; use visuals heavily
+
+---
+
+## N5-N4 Transition Videos
+
+*Growing vocabulary, natural conversation, contemporary settings. Mix of casual and slightly formal Japanese.*
+
+### Slice-of-Life Anime (12-Episode Series)
+
+- **Non Non Biyori** (のんのんびより)
+  - *Format:* Anime series (12-13 episodes, 24 min each)
+  - *Learning Value:* Rural Japan setting, natural dialogue, relatable scenarios
+  - *Content:* Four girls' daily life in countryside
+  - *Speech Pace:* Moderate; characters speak at natural speed
+
+- **Nichijou** (日常)
+  - *Format:* Anime series (26 episodes, 24 min each)
+  - *Learning Value:* Comedy relies on wordplay and visual humor
+  - *Content:* Absurdist comedy about normal high school life
+  - *Note:* Humor helps with engagement despite language difficulty
+
+- **Yotsuba&!** (よつばと!)
+  - *Format:* Manga adaptation concept
+  - *Learning Value:* Simple, curious perspective of a young child
+  - *Content:* A girl explores the world with wonder
+  - *Availability:* Primarily manga-based; limited anime
+
+- **Polar Bear Café** (しろくまカフェ)
+  - *Format:* Anime series (50 episodes, 24 min each)
+  - *Learning Value:* Dialogue-heavy comedy; everyday conversation patterns
+  - *Content:* Animals running a café; slice-of-life interactions
+  - *Speech Pace:* Clear dialogue designed for understanding
+
+### Cute/Wholesome Anime
+
+- **A Place Further Than the Universe** (ここから、始まる冒険)
+  - *Format:* Anime series (13 episodes, 24 min each)
+  - *Learning Value:* Coming-of-age themes, motivational dialogue
+  - *Content:* High school girls plan a journey to Antarctica
+  - *Character Focus:* Strong character development aids comprehension
+
+- **The Helpful Fox Senko-san** (世話焼きキツネの仙狐さん)
+  - *Format:* Anime series (12 episodes, 24 min each)
+  - *Learning Value:* Supernatural care-taking scenario with natural conversation
+  - *Content:* A fox spirit helps a stressed office worker
+  - *Speech Pace:* Calm, clear dialogue
+
+### Japanese Live-Action Dramas
+
+- **Asadora!** (朝ドラ - NHK Morning Drama)
+  - *Format:* TV drama series (156 episodes, 15 min each)
+  - *Learning Value:* Authentic contemporary Japanese, period dialogue
+  - *Content:* Coming-of-age stories set in modern Japan
+  - *Note:* Each series has different protagonist/story
+
+- **Terrace House** (テラスハウス)
+  - *Format:* Reality TV series (episodes vary)
+  - *Learning Value:* Unscripted natural conversation
+  - *Content:* Young adults living together; slice-of-life documentary style
+  - *Note:* Modern casual Japanese; sometimes slower-paced
+
+### Studio Ghibli Films (N5-N4 Transition)
+
+- **Howl's Moving Castle** (ハウルの動く城)
+  - *Format:* Feature film (119 min)
+  - *Learning Value:* Fantasy elements combined with character dialogue
+  - *Content:* A young woman and a mysterious wizard
+  - *Difficulty Note:* Slightly more complex than Totoro but visually rich
+
+- **The Wind Rises** (風立ちぬ)
+  - *Format:* Feature film (126 min)
+  - *Learning Value:* Historical setting, romantic dialogue
+  - *Content:* Biographical drama about an aircraft designer
+  - *Difficulty Note:* More mature themes; formal language at times
+
+---
+
+## N4+ Level Videos
+
+*Complex narratives, varied vocabulary, some formal/literary language. Suitable for intermediate learners.*
+
+### Coming-of-Age Films
+
+- **Your Name** (君の名は)
+  - *Format:* Feature film (106 min)
+  - *Learning Value:* Contemporary urban Tokyo dialogue, emotional expression
+  - *Content:* Two teenagers mysteriously swap bodies
+  - *Popularity:* Highest-grossing anime film; modern cultural reference
+
+- **The Girl Who Leapt Through Time** (時をかける少女)
+  - *Format:* Feature film (98 min)
+  - *Learning Value:* Time travel narrative, philosophical dialogue
+  - *Content:* A girl discovers she can leap through time
+  - *Speech Pace:* Natural; moderate difficulty
+
+- **A Silent Voice** (聲の形)
+  - *Format:* Feature film (130 min)
+  - *Learning Value:* Deep character development, emotional complexity
+  - *Content:* Redemption story between bullied student and former bully
+  - *Themes:* Disability representation, forgiveness, acceptance
+
+- **I Want to Eat Your Pancreas** (君膵)
+  - *Format:* Feature film (108 min)
+  - *Learning Value:* Philosophical dialogue, character introspection
+  - *Content:* Two high school students meet through a secret diary
+  - *Emotional Content:* Touching story; accessible language despite themes
+
+### Complex Anime Series (13-26 episodes)
+
+- **Demon Slayer** (鬼滅の刃) - Select episodes
+  - *Format:* Anime series (multiple seasons, 24 min episodes)
+  - *Learning Value:* Action dialogue, emotional character interactions
+  - *Content:* Young demon slayer protecting humanity
+  - *Note:* Later episodes more complex; Season 1 manageable for N4
+
+- **Attack on Titan** (進撃の巨人) - With context
+  - *Format:* Anime series (87 episodes, 24 min each)
+  - *Learning Value:* Complex plot, strategic dialogue
+  - *Content:* Humans fighting giant humanoid creatures
+  - *Difficulty:* Better watched with subtitles; plot-heavy
+
+- **Death Note** (デスノート)
+  - *Format:* Anime series (37 episodes, 24 min each)
+  - *Learning Value:* Strategic dialogue, psychological narrative
+  - *Content:* Student with supernatural notebook determines fates
+  - *Speech Pace:* Clear but intellectually demanding
+
+### Fantasy & Adventure Films
+
+- **Spirited Away** (千と千尋の神隠し) - Revisited
+  - *Format:* Feature film (125 min)
+  - *Learning Value:* Rich vocabulary, formal spirit world language
+  - *Content:* Girl navigating a bathhouse in spirit world
+  - *Difficulty:* Pushes into N4; visuals help significantly
+
+- **Princess Mononoke** (もののけ姫)
+  - *Format:* Feature film (134 min)
+  - *Learning Value:* Sophisticated dialogue, multiple perspectives
+  - *Content:* Forest spirit conflict between humans and nature
+  - *Themes:* Environmental, political, philosophical
+  - *Difficulty Note:* Ghibli's most complex; formal language
+
+- **Nausicaä of the Valley of the Wind** (風の谷のナウシカ)
+  - *Format:* Feature film (117 min)
+  - *Learning Value:* Post-apocalyptic narrative, character determination
+  - *Content:* Princess navigates toxic forest and political conflict
+  - *Themes:* Environmental themes, peaceful resistance
+
+### Contemporary Drama Films
+
+- **Before the Coffee Gets Cold** (コーヒーが冷めないうちに)
+  - *Format:* Feature film (122 min)
+  - *Learning Value:* Philosophical dialogue, emotional introspection
+  - *Content:* Customers in a café experience time-related wishes
+  - *Themes:* Regret, connection, redemption
+  - *Speech Pace:* Natural; introspective rather than action-driven
+
+- **Delicious in Dungeon** (ダンジョン飯)
+  - *Format:* Anime series (24 episodes, 24 min each)
+  - *Learning Value:* Fantasy worldbuilding, character banter
+  - *Content:* Party cooks monsters while rescuing captured sister
+  - *Humor:* Helps with engagement; dialogue-heavy
+
+- **Silver Spoon** (銀の匙)
+  - *Format:* Anime series (22 episodes, 24 min each; Season 1-2)
+  - *Learning Value:* School setting with rural agricultural focus
+  - *Content:* Urban boy attending agricultural high school
+  - *Themes:* Rural life, friendship, coming-of-age
+  - *Speech:* Natural teenage dialogue
+
+### Ghibli's Most Complex Works
+
+- **Howl's Moving Castle** (ハウルの動く城) - Revisited
+  - *Format:* Feature film (119 min)
+  - *Learning Value:* Romantic dialogue, fantasy terminology
+  - *Content:* Woman cursed to old age; meets mysterious wizard
+  - *Themes:* Self-worth, courage, love
+
+- **The Wind Rises** (風立ちぬ) - Revisited
+  - *Format:* Feature film (126 min)
+  - *Learning Value:* Historical narrative, formal language
+  - *Content:* Inspired by real aircraft designer Jiro Horikoshi
+  - *Themes:* Dreams, art, history, romance
+
+---
+
+## Documentary & Educational Content
+
+*Non-fictional content that provides cultural and linguistic context.*
+
+### Nature & Culture Documentaries
+
+- **Planet Earth / Blue Planet** (Japanese dub available)
+  - *Format:* Documentary series (episodes vary)
+  - *Learning Value:* Narration-heavy; scientific/nature vocabulary
+  - *Content:* Wildlife and natural phenomena
+  - *Pace:* Slower, descriptive narration
+
+- **Japanese Cultural Documentaries** (NHK Productions)
+  - *Format:* Documentary series (30-50 min)
+  - *Learning Value:* Cultural context, formal explanatory Japanese
+  - *Content:* Festivals, crafts, regions, traditions
+  - *Examples:* 日本の手仕事 (Japanese Craftsmanship), 美の壺 (The Art of Living)
+
+### Language Learning Shows
+
+- **NHK World - Easy Japanese Drama** (やさしい日本語)
+  - *Format:* Mini-dramas (5-10 min)
+  - *Learning Value:* Specifically designed for learners
+  - *Content:* Cultural scenarios, greetings, daily interactions
+  - *Subtitles:* Usually available in English and Japanese
+
+---
+
+## Recommendations by Learning Goal
+
+### For Listening Practice
+- Start with **Anpanman** or **Chi's Sweet Home** (slow, repetitive)
+- Progress to **NHK Educational content** (clear enunciation)
+- Move to **Doraemon** or **Crayon Shin-chan** (natural but still simple)
+
+### For Cultural Immersion
+- **Studio Ghibli films** (any level; culturally rich)
+- **Non Non Biyori** (rural Japanese life)
+- **NHK Morning Dramas** (contemporary Japan)
+
+### For Vocabulary Building
+- **Polar Bear Café** (dialogue-heavy, everyday vocabulary)
+- **Non Non Biyori** (nature and daily life terms)
+- **The Girl Who Leapt Through Time** (varied situations)
+
+### For Motivation & Enjoyment
+- **Your Name** (engaging story, relatability)
+- **Demon Slayer** (exciting action, beautiful animation)
+- **A Silent Voice** (emotional depth, meaningful themes)
+
+### For Grammar in Context
+- **Terrace House** (unscripted, natural speech patterns)
+- **Your Name** (varied registers: casual, formal, emotional)
+- **Death Note** (strategic dialogue with varied structures)
+
+---
+
+## Streaming & Availability Notes
+
+- **Netflix:** Many anime series, Studio Ghibli films (varies by region)
+- **Crunchyroll:** Extensive anime library
+- **Amazon Prime Video:** Films and series
+- **YouTube:** Some official clips, educational content
+- **NHK World:** Free educational content with subtitles
+- **Physical Media:** DVDs/Blu-rays with subtitles available for many titles
+
+---
+
+## Tips for Viewing
+
+1. **Start with subtitles** (Japanese subtitles when possible, not English)
+2. **Rewatch episodes** — you'll catch more each time
+3. **Pause and repeat** difficult sections
+4. **Match content to your level** — visual storytelling helps at lower levels
+5. **Choose stories that interest you** — motivation is key
+6. **Use multiple sources** — variety keeps learning fresh
+

--- a/VIDEOS.md
+++ b/VIDEOS.md
@@ -62,6 +62,10 @@ This document provides a comprehensive list of movies, TV shows, and animated co
 
 ### Very Young Children's Shows (Ages 4-7)
 
+#### Original Japanese Content
+
+**NHK Educational Programming**
+
 - **いないいないばあっ!** (Peek-a-Boo!)
   - *Format:* NHK educational TV (15 min episodes)
   - *Learning Value:* Designed for babies/toddlers; extremely simple, repetitive
@@ -74,23 +78,31 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* Educational songs, dance, character interactions
   - *Features:* Counting, colors, emotions, daily routines
 
+- **ニャッキ** (Nyaki)
+  - *Format:* NHK short animation series
+  - *Learning Value:* Minimal dialogue; musical, quirky adventures
+  - *Content:* Yellow creature exploring the world
+  - *Themes:* Discovery, curiosity, music
+
+**Original Japanese Anime Series**
+
 - **しまじろう** (Shimajiro)
   - *Format:* Anime series (11 min episodes)
   - *Learning Value:* Toddler protagonist; relatable daily life; simple dialogue
   - *Content:* Tiger cub and friends navigating preschool/early school
   - *Themes:* Sharing, friendship, emotions, learning
 
-- **きかんしゃトーマス** (Thomas the Tank Engine - Japanese dub)
-  - *Format:* Anime series (11-26 min episodes)
-  - *Learning Value:* Minimal character dialogue; narration-driven
-  - *Content:* Colorful trains and their adventures
-  - *Advantage:* Charming visuals; easy to follow without understanding every word
+- **アンパンマン** (Anpanman) — Episodes 1-20 (earliest/simplest)
+  - *Format:* Anime series (15-25 min episodes)
+  - *Learning Value:* Extremely simple vocabulary, repetitive dialogue, visual cues
+  - *Content:* Adventures of a superhero with a bread head; pure comfort viewing
+  - *Note:* Repetitive adventures; same villain, predictable outcomes
 
-- **ミッフィー** (Miffy/Nijntje)
-  - *Format:* Anime series (7 min episodes)
-  - *Learning Value:* Ultra-simple picture book style; minimal dialogue
-  - *Content:* Cute rabbit and gentle adventures
-  - *Perfect for:* Very visual learners; calming content
+- **ハムタロウ** (Hamtaro - Pocketful of Hamsters)
+  - *Format:* Anime series (296 episodes, 11 min each)
+  - *Learning Value:* Extremely simple for very young learners; minimal dialogue
+  - *Content:* Cute hamster adventures with friends
+  - *Pace:* Very slow; excellent for absolute beginners
 
 - **メルちゃん** (Mell-chan)
   - *Format:* Anime series (24 min episodes)
@@ -98,15 +110,118 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* A cheerful doll and her friends
   - *Themes:* Friendship, caring, imagination
 
-- **アンパンマン** (revisited for very young)
-  - *Episodes:* Episodes 1-20 (earliest/simplest)
-  - *Note:* Repetitive adventures; same villain, predictable outcomes
-  - *Perfect for:* Youngest viewers; pure comfort viewing
+- **たまごっち！** (Tamagotchi!)
+  - *Format:* Anime series (70+ episodes, 24 min each)
+  - *Learning Value:* Cute characters, simple slice-of-life narratives
+  - *Content:* Digital pet characters come to life
+  - *Themes:* Friendship, responsibility, adventure
 
-- **カラー・カットくん** (Color Cutter)
-  - *Format:* Educational short series
-  - *Learning Value:* Primary colors, shapes, creative play
-  - *Content:* Learning through color and shape recognition
+- **ハローキティ** (Hello Kitty & Friends) — Sanrio Original
+  - *Format:* Anime series (various, 24 min episodes)
+  - *Learning Value:* Super simple; designed for young children
+  - *Content:* Sanrio character adventures and daily life
+  - *Advantage:* Extremely approachable with minimal language barriers
+
+- **パーマン** (Perman)
+  - *Format:* Anime series (episodes vary, 24 min)
+  - *Learning Value:* Classic comedy with simple dialogue patterns
+  - *Content:* Boy becomes a masked superhero with gadgets
+  - *Note:* Nostalgic classic; humor based on visuals and repetition
+
+- **ドラえもん** (Doraemon) — Early episodes
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Everyday conversation, simple explanations, comedy for context
+  - *Content:* A robot cat from the future helps with daily problems
+
+- **チーズスイートホーム** (Chi's Sweet Home)
+  - *Format:* Anime series (4 min episodes)
+  - *Learning Value:* Short episodes, simple narration, pet perspective
+  - *Content:* A kitten adjusting to a new home; cuteness helps with engagement
+
+- **ゲゲゲの鬼太郎** (Gegege no Kitaro) — Select episodes
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Folklore-based; iconic yokai/ghost characters
+  - *Content:* Boy with supernatural powers fights demons
+  - *Note:* Slightly spooky but not scary; very Japanese folklore
+
+- **妖怪ウォッチ** (Yo-Kai Watch) — Early episodes
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Modern folklore meets creature-catching adventure
+  - *Content:* Boy discovers and befriends invisible Yo-Kai creatures
+  - *Popularity:* Hugely popular with Japanese children ages 5-8
+
+- **リラックマ** (Rilakkuma)
+  - *Format:* Anime shorts/series
+  - *Learning Value:* Minimal dialogue; adorable character interactions
+  - *Content:* Lazy bear and friends' cozy adventures
+  - *Perfect for:* Gentle, relaxing content
+
+**Original Japanese Films & Picture Books**
+
+- **となりのトトロ** (My Neighbor Totoro)
+  - *Format:* Studio Ghibli feature film (88 min)
+  - *Learning Value:* Slow pacing, simple dialogue, beautiful visuals tell the story
+  - *Content:* Sisters encounter friendly forest spirits
+  - *Note:* Quintessential Japanese film for young children
+
+- **ぐりとぐら** (Guri and Gura)
+  - *Format:* Picture book adaptation/shorts (10-15 min)
+  - *Learning Value:* Classic Japanese picture book; minimal dialogue
+  - *Content:* Two hedgehog friends' simple adventures
+  - *Themes:* Cooking, friendship, nature
+
+- **きんぎょがにげた** (Goldfish Are Escaping)
+  - *Format:* Picture book adaptation (10 min)
+  - *Learning Value:* Search-and-find format; simple narration
+  - *Content:* Boy searches for escaped goldfish
+  - *Interactive:* Viewers look for goldfish on screen
+
+- **わたしのワンピース** (My One-Piece Dress)
+  - *Format:* Picture book animation (10 min)
+  - *Learning Value:* Color and nature vocabulary
+  - *Content:* Girl's magical dress changes with surroundings
+  - *Themes:* Imagination, creativity, nature
+
+- **ねずみくんのチョッキ** (Mice Man's Vest)
+  - *Format:* Picture book adaptation (10 min)
+  - *Learning Value:* Clothing vocabulary; repetitive structure
+  - *Content:* Mouse's sweater borrowed by increasingly large animals
+  - *Perfect for:* Repetition-based learning
+
+#### International Content (Japanese Dub)
+
+**More Original Japanese Anime for Young Children**
+
+- **ポケットモンスター** (Pokémon) — Early Kanto episodes (Japanese original)
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Simple adventures, repetitive battle structure
+  - *Content:* Ash and Pikachu's journey to become Pokémon master
+  - *Tip:* Early episodes simpler than later seasons; created in Japan
+
+- **かいけつゾロリ** (Zoro the Great Adventure)
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Comedic adventure; visual humor; simple explanations
+  - *Content:* Clever fox and animal friends solving mysteries
+  - *Age Group:* Ages 5-8 friendly; original Japanese
+
+- **ワニワニパニック** - Various educational anime compilations
+  - *Format:* Short segments
+  - *Learning Value:* Educational content; number recognition, letters
+  - *Content:* Simple lessons wrapped in animation
+
+**International Shows (Japanese Dub)**
+
+- **きかんしゃトーマス** (Thomas the Tank Engine - Japanese dub)
+  - *Format:* Anime series (11-26 min episodes)
+  - *Learning Value:* Minimal character dialogue; narration-driven
+  - *Content:* Colorful trains and their adventures
+  - *Advantage:* Charming visuals; easy to follow without understanding every word
+
+- **ミッフィー** (Miffy/Nijntje - Japanese dub)
+  - *Format:* Anime series (7 min episodes)
+  - *Learning Value:* Ultra-simple picture book style; minimal dialogue
+  - *Content:* Cute rabbit and gentle adventures
+  - *Perfect for:* Very visual learners; calming content
 
 - **ピングー** (Pingu - Japanese dub)
   - *Format:* Stop-motion series (5-7 min episodes)
@@ -120,32 +235,7 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* Bear and friends in Hundred Acre Wood
   - *Perfect for:* Calming content with simple daily adventures
 
-### Popular Anime for Young Children
-
-- **ポケットモンスター** (Pokémon) — Early Kanto episodes
-  - *Format:* Anime series (24 min episodes)
-  - *Learning Value:* Simple adventures, repetitive battle structure
-  - *Content:* Ash and Pikachu's journey to become Pokémon master
-  - *Tip:* Early episodes simpler than later seasons
-
-- **かいけつゾロリ** (Zoro the Great Adventure)
-  - *Format:* Anime series (24 min episodes)
-  - *Learning Value:* Comedic adventure; visual humor; simple explanations
-  - *Content:* Clever fox and animal friends solving mysteries
-  - *Age Group:* Ages 5-8 friendly
-
-- **ニャッキ** (Nyaki)
-  - *Format:* NHK short animation series
-  - *Learning Value:* Minimal dialogue; musical, quirky adventures
-  - *Content:* Yellow creature exploring the world
-  - *Themes:* Discovery, curiosity, music
-
-- **ワニワニパニック** - Various educational anime compilations
-  - *Format:* Short segments
-  - *Learning Value:* Educational content; number recognition, letters
-  - *Content:* Simple lessons wrapped in animation
-
-### Disney & Pixar Films (Japanese Dub)
+**Disney & Pixar Films (Japanese Dub - International)**
 
 - **ライオン・キング** (The Lion King)
   - *Format:* Feature film (88 min)
@@ -255,46 +345,22 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* Rabbit cop and fox investigate crime
   - *Humor:* Visual gags + clever dialogue
 
-### Picture Book Adaptations & Visual Stories
+**Picture Book Adaptations (Japanese)**
 
-- **ぐりとぐら** (Guri and Gura)
-  - *Format:* Picture book adaptation/shorts (10-15 min)
-  - *Learning Value:* Classic Japanese picture book; minimal dialogue
-  - *Content:* Two hedgehog friends' simple adventures
-  - *Themes:* Cooking, friendship, nature
-
-- **きんぎょがにげた** (Goldfish Are Escaping)
-  - *Format:* Picture book adaptation (10 min)
-  - *Learning Value:* Search-and-find format; simple narration
-  - *Content:* Boy searches for escaped goldfish
-  - *Interactive:* Viewers look for goldfish on screen
-
-- **はらぺこあおむし** (The Very Hungry Caterpillar)
+- **はらぺこあおむし** (The Very Hungry Caterpillar - Japanese adaptation)
   - *Format:* Picture book animation (6 min)
   - *Learning Value:* Food vocabulary; metamorphosis concept
   - *Content:* Caterpillar's week-long eating journey
   - *Perfect for:* Youngest learners; beloved classic
 
-- **わたしのワンピース** (My One-Piece Dress)
-  - *Format:* Picture book animation (10 min)
-  - *Learning Value:* Color and nature vocabulary
-  - *Content:* Girl's magical dress changes with surroundings
-  - *Themes:* Imagination, creativity, nature
+**International Shows (Japanese Dub)**
 
-- **ねずみくんのチョッキ** (Mice Man's Vest)
-  - *Format:* Picture book adaptation (10 min)
-  - *Learning Value:* Clothing vocabulary; repetitive structure
-  - *Content:* Mouse's sweater borrowed by increasingly large animals
-  - *Perfect for:* Repetition-based learning
-
-### International Shows (Japanese Dub)
-
-- **ブルーイ** (Bluey) — Already listed, worth emphasizing
+- **ブルーイ** (Bluey - Australian, Japanese dub)
   - *Format:* Animated series (7 min episodes)
   - *For Ages:* 4-6 perfect audience
   - *Repeat Viewing:* Episodes often repeated; families watch same ones multiple times
 
-- **ペッパ・ピッグ** (Peppa Pig)
+- **ペッパ・ピッグ** (Peppa Pig - British, Japanese dub)
   - *Format:* Animated series (5 min episodes)
   - *Learning Value:* Preschool family dynamics; simple British content
   - *Content:* Piglet family's daily adventures
@@ -305,49 +371,52 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Learning Value:* British politeness; simple family dynamics
   - *Content:* Bear in London; heartwarming adventures
 
-- **アーサーとミニモイ** (Arthur and the Minimoys)
+- **アーサーとミニモイ** (Arthur and the Minimoys - French, Japanese dub)
   - *Format:* Animated film (94 min)
   - *Learning Value:* Fantasy adventure; imaginative world
   - *Content:* Boy discovers tiny civilization in garden
   - *Themes:* Adventure, courage, environmental awareness
 
-- **セサミ・ストリート** (Sesame Street - Japanese version, if available)
+- **セサミ・ストリート** (Sesame Street - Japanese version)
   - *Format:* Educational TV series
   - *Learning Value:* Alphabet, numbers, social skills
   - *Content:* Muppets and human friends learning together
   - *Classic:* Timeless educational format
 
-### Other Very Young-Friendly Films
+**Original Japanese Films (Young-Friendly)**
 
-- **メアリと魔女の花** (Mary and the Witch's Flower) — Already listed, emphasizing for young viewers
-  - *Format:* Feature film (102 min)
+- **メアリと魔女の花** (Mary and the Witch's Flower)
+  - *Format:* Studio Ponoc feature film (102 min)
   - *For Young Kids:* Magical girl adventure, not too scary
+  - *Note:* Japanese studio, inspired by classic literature
 
-- **ウォーリー** (WALL-E)
+**International Films (Japanese Dub)**
+
+- **ウォーリー** (WALL-E - American, Japanese dub)
   - *Format:* Feature film (98 min)
   - *Learning Value:* Minimal dialogue; love story told through actions
   - *Content:* Robot's lonely world and adventure
   - *Perfect for:* Visual learners; unique soundtrack
 
-- **ターボ** (Turbo)
+- **ターボ** (Turbo - American, Japanese dub)
   - *Format:* Feature film (96 min)
   - *Learning Value:* Dream-focused adventure; inspiring protagonist
   - *Content:* Snail who dreams of racing
   - *Themes:* Dreams, determination, individuality
 
-- **ペット** (The Secret Life of Pets)
+- **ペット** (The Secret Life of Pets - American, Japanese dub)
   - *Format:* Feature film (87 min)
   - *Learning Value:* Urban setting; character-driven comedy
   - *Content:* Pets' secret lives while owners away
   - *Humor:* Physical comedy; relatable pet situations
 
-- **モンスター・ホテル** (Hotel Transylvania)
+- **モンスター・ホテル** (Hotel Transylvania - American, Japanese dub)
   - *Format:* Feature film (91 min)
   - *Learning Value:* Monster characters; father-daughter story
   - *Content:* Dracula's hotel; comedy over scares
   - *Note:* Monsters are silly, not scary
 
-- **ヒックとドラゴン** (How to Train Your Dragon)
+- **ヒックとドラゴン** (How to Train Your Dragon - American, Japanese dub)
   - *Format:* Feature film (98 min)
   - *Learning Value:* Adventure; underdog story; character growth
   - *Content:* Boy befriends dragon

--- a/VIDEOS.md
+++ b/VIDEOS.md
@@ -30,6 +30,36 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Learning Value:* Casual family dialogue, comedic context aids understanding
   - *Content:* Family comedy; episodes have repetitive humor patterns
 
+- **Hamtaro** (ハムタロウ - Pocketful of Hamsters)
+  - *Format:* Anime series (296 episodes, 11 min each)
+  - *Learning Value:* Extremely simple for very young learners; minimal dialogue
+  - *Content:* Cute hamster adventures with friends
+  - *Pace:* Very slow; excellent for absolute beginners
+
+- **Astro Boy** (鉄腕アトム) — 2003 series
+  - *Format:* Anime series (50 episodes, 24 min each)
+  - *Learning Value:* Classic robot adventures; simple but clear dialogue
+  - *Content:* Powerful robot boy protecting humanity
+  - *Pace:* Engaging enough to maintain interest despite simplicity
+
+- **Tamagotchi!** (たまごっち！)
+  - *Format:* Anime series (70+ episodes, 24 min each)
+  - *Learning Value:* Cute characters, simple slice-of-life narratives
+  - *Content:* Digital pet characters come to life
+  - *Themes:* Friendship, responsibility, adventure
+
+- **Hello Kitty & Friends** (ハローキティ series)
+  - *Format:* Anime series (various, 24 min episodes)
+  - *Learning Value:* Super simple; designed for young children
+  - *Content:* Sanrio character adventures and daily life
+  - *Advantage:* Extremely approachable with minimal language barriers
+
+- **Perman** (パーマン)
+  - *Format:* Anime series (episodes vary, 24 min)
+  - *Learning Value:* Classic comedy with simple dialogue patterns
+  - *Content:* Boy becomes a masked superhero with gadgets
+  - *Note:* Nostalgic classic; humor based on visuals and repetition
+
 ### Studio Ghibli Films (Beginner-Friendly)
 
 - **My Neighbor Totoro** (となりのトトロ)
@@ -50,6 +80,44 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* A fish-girl and a boy's friendship
   - *Difficulty Note:* Dreamlike quality allows for understanding gaps
 
+- **The Secret World of Arrietty** (借りぐらしのアリエッティ)
+  - *Format:* Feature film (104 min)
+  - *Learning Value:* Whispered, gentle dialogue; simple descriptions of daily tasks
+  - *Content:* Tiny family living undetected in human home
+  - *Pace:* Slower, contemplative story with clear visuals
+
+- **The Red Turtle** (赤い亀)
+  - *Format:* Feature film (80 min)
+  - *Learning Value:* Almost no dialogue; purely visual storytelling
+  - *Content:* Man stranded on island befriends a turtle
+  - *Perfect for:* Listening practice without language pressure; enjoy the story visually
+
+### Wholesome & Slice-of-Life Anime (Beginner-Suitable)
+
+- **Kamichu!** (かみちゅ！)
+  - *Format:* Anime series (16 episodes, 24 min each)
+  - *Learning Value:* School setting, gentle comedy, clear dialogue
+  - *Content:* Shy girl discovers she's a Shinto goddess
+  - *Themes:* School life, friendship, supernatural discovery
+
+- **Tamayura** (たまゆら)
+  - *Format:* Anime series (16 episodes, 24 min each)
+  - *Learning Value:* Photography-focused; everyday activities and nature
+  - *Content:* Girls in photography club exploring their town
+  - *Pace:* Calm, contemplative narrative
+
+- **Azuki-chan** (あずきちゃん)
+  - *Format:* Anime series (50 episodes, 24 min each)
+  - *Learning Value:* Cooking-themed; repetitive recipes and kitchen vocabulary
+  - *Content:* Girl loves cooking; shares recipes with friends
+  - *Bonus:* Learn cooking vocabulary while enjoying story
+
+- **Aggretsuko** (アグレッシブ烈子) — Select episodes
+  - *Format:* Anime series (seasons vary, 12-25 min episodes)
+  - *Learning Value:* Short episodes; office/daily life with expressive characters
+  - *Content:* Red panda office worker; slice-of-life comedy
+  - *Note:* Start with Season 1 for simpler language
+
 ### NHK Educational Content
 
 - **NHK Eテレ Kids Programs**
@@ -63,13 +131,79 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Learning Value:* Specifically designed for learners; subtitles available
   - *Content:* Daily scenarios, cultural explanations
 
-### Ghibli Short Films
+- **Eテレ Originals** (NHK Educational Programming)
+  - *Format:* Various shorts (5-20 min)
+  - *Learning Value:* Science, nature, and social lessons for children
+  - *Content:* Experiments, nature observation, life skills
+  - *Examples:* サイエンスゼロ (Science Zero - simplified), Nature documentaries
+
+### Other Studio Ghibli Films
 
 - **Spirited Away** (千と千尋の神隠し) - *Note: More complex, but highly visual*
   - *Format:* Feature film (125 min)
   - *Learning Value:* Fantastical visuals compensate for language difficulty
   - *Content:* Girl navigating a spirit world
   - *Difficulty Note:* Borderline N5/N4; use visuals heavily
+
+- **Castle in the Sky** (ラピュタ - 天空の城ラピュタ)
+  - *Format:* Feature film (124 min)
+  - *Learning Value:* Adventure story with clear action and emotional beats
+  - *Content:* Two teens search for legendary floating castle
+  - *Difficulty Note:* More action-driven than dialogue-dependent; visuals carry story
+
+- **Howl's Moving Castle** (ハウルの動く城) - *Early scenes*
+  - *Format:* Feature film (119 min)
+  - *Learning Value:* Beautiful visuals; romantic scenes have slower, clearer dialogue
+  - *Content:* Woman cursed to old age meets mysterious wizard
+  - *Tip:* The opening and romantic scenes are more accessible than action sequences
+
+### Ultra-Short Form Content (5-15 minutes)
+
+- **Pop Team Epic** (ポプテピピック)
+  - *Format:* Anime series (3-5 min episodes)
+  - *Learning Value:* Surreal comedy; visual humor dominates; minimal language needed
+  - *Content:* Absurdist comedy with rapid-fire jokes
+  - *Perfect for:* Quick daily viewing; humor transcends language
+
+- **Splatoon Short Films** (スプラトゥーン)
+  - *Format:* Short anime films (5-15 min)
+  - *Learning Value:* Action-driven; simple dialogue between colorful characters
+  - *Content:* Video game universe adaptations
+  - *Visuals:* Bright and engaging; story secondary to action
+
+- **Official Sanrio Character Shorts**
+  - *Format:* Various shorts (5-10 min)
+  - *Learning Value:* Minimal dialogue; adorable character interactions
+  - *Content:* Hello Kitty, Badtz-Maru, and other Sanrio character adventures
+  - *Perfect for:* Stress relief + listening practice combined
+
+### International Children's Content (Japanese Dub)
+
+- **Bluey** (ブルーイ - Australian show, Japanese dub available)
+  - *Format:* Animated series (7 min episodes)
+  - *Learning Value:* Very simple family dialogue; repetitive vocabulary
+  - *Content:* Blue heeler puppy family's everyday adventures
+  - *Perfect for:* Absolute beginners; relatable family scenarios
+
+- **Peppa Pig** (ペッパピッグ - Japanese dub)
+  - *Format:* Animated series (5 min episodes)
+  - *Learning Value:* Designed for preschoolers; extremely simple dialogue
+  - *Content:* Pig family adventures
+  - *Advantage:* Extremely clear pronunciation; repetitive patterns
+
+### Stop-Motion & Visual-Heavy Films
+
+- **Mary and the Witch's Flower** (メアリと魔女の花)
+  - *Format:* Feature film (102 min)
+  - *Learning Value:* Magical adventure; visually driven; simple character interactions
+  - *Content:* Girl finds magical flower and gains witch powers
+  - *Studio:* Studio Ponoc (Ghibli-adjacent quality)
+
+- **Patema Inverted** (パテマ・インバーテッド)
+  - *Format:* Feature film (98 min)
+  - *Learning Value:* Science-fiction concept; relatively simple dialogue; visual-heavy
+  - *Content:* Girl discovers people living upside-down
+  - *Pace:* Engaging mystery that holds attention despite language difficulty
 
 ---
 

--- a/VIDEOS.md
+++ b/VIDEOS.md
@@ -60,6 +60,299 @@ This document provides a comprehensive list of movies, TV shows, and animated co
   - *Content:* Boy becomes a masked superhero with gadgets
   - *Note:* Nostalgic classic; humor based on visuals and repetition
 
+### Very Young Children's Shows (Ages 4-7)
+
+- **いないいないばあっ!** (Peek-a-Boo!)
+  - *Format:* NHK educational TV (15 min episodes)
+  - *Learning Value:* Designed for babies/toddlers; extremely simple, repetitive
+  - *Content:* Interactive peek-a-boo games with characters
+  - *Perfect for:* Youngest learners; visual + simple sound patterns
+
+- **おかあさんといっしょ** (With Mom)
+  - *Format:* NHK daily program (20 min)
+  - *Learning Value:* Songs, movement, extremely clear speech
+  - *Content:* Educational songs, dance, character interactions
+  - *Features:* Counting, colors, emotions, daily routines
+
+- **しまじろう** (Shimajiro)
+  - *Format:* Anime series (11 min episodes)
+  - *Learning Value:* Toddler protagonist; relatable daily life; simple dialogue
+  - *Content:* Tiger cub and friends navigating preschool/early school
+  - *Themes:* Sharing, friendship, emotions, learning
+
+- **きかんしゃトーマス** (Thomas the Tank Engine - Japanese dub)
+  - *Format:* Anime series (11-26 min episodes)
+  - *Learning Value:* Minimal character dialogue; narration-driven
+  - *Content:* Colorful trains and their adventures
+  - *Advantage:* Charming visuals; easy to follow without understanding every word
+
+- **ミッフィー** (Miffy/Nijntje)
+  - *Format:* Anime series (7 min episodes)
+  - *Learning Value:* Ultra-simple picture book style; minimal dialogue
+  - *Content:* Cute rabbit and gentle adventures
+  - *Perfect for:* Very visual learners; calming content
+
+- **メルちゃん** (Mell-chan)
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Doll character; daily life and self-care routines
+  - *Content:* A cheerful doll and her friends
+  - *Themes:* Friendship, caring, imagination
+
+- **アンパンマン** (revisited for very young)
+  - *Episodes:* Episodes 1-20 (earliest/simplest)
+  - *Note:* Repetitive adventures; same villain, predictable outcomes
+  - *Perfect for:* Youngest viewers; pure comfort viewing
+
+- **カラー・カットくん** (Color Cutter)
+  - *Format:* Educational short series
+  - *Learning Value:* Primary colors, shapes, creative play
+  - *Content:* Learning through color and shape recognition
+
+- **ピングー** (Pingu - Japanese dub)
+  - *Format:* Stop-motion series (5-7 min episodes)
+  - *Learning Value:* Almost no dialogue; penguin sounds and music tell the story
+  - *Content:* Penguin family adventures in Antarctic
+  - *Advantage:* Pure visual storytelling; universal humor
+
+- **くまのプーさん** (Winnie the Pooh - Japanese version)
+  - *Format:* Animated series/films
+  - *Learning Value:* Slow pacing, gentle characters, minimal dialogue
+  - *Content:* Bear and friends in Hundred Acre Wood
+  - *Perfect for:* Calming content with simple daily adventures
+
+### Popular Anime for Young Children
+
+- **ポケットモンスター** (Pokémon) — Early Kanto episodes
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Simple adventures, repetitive battle structure
+  - *Content:* Ash and Pikachu's journey to become Pokémon master
+  - *Tip:* Early episodes simpler than later seasons
+
+- **かいけつゾロリ** (Zoro the Great Adventure)
+  - *Format:* Anime series (24 min episodes)
+  - *Learning Value:* Comedic adventure; visual humor; simple explanations
+  - *Content:* Clever fox and animal friends solving mysteries
+  - *Age Group:* Ages 5-8 friendly
+
+- **ニャッキ** (Nyaki)
+  - *Format:* NHK short animation series
+  - *Learning Value:* Minimal dialogue; musical, quirky adventures
+  - *Content:* Yellow creature exploring the world
+  - *Themes:* Discovery, curiosity, music
+
+- **ワニワニパニック** - Various educational anime compilations
+  - *Format:* Short segments
+  - *Learning Value:* Educational content; number recognition, letters
+  - *Content:* Simple lessons wrapped in animation
+
+### Disney & Pixar Films (Japanese Dub)
+
+- **ライオン・キング** (The Lion King)
+  - *Format:* Feature film (88 min)
+  - *Learning Value:* Epic adventure with simple emotional beats
+  - *Content:* Young lion's journey to adulthood
+  - *Advantage:* Music-driven narrative; visuals compensate for language
+
+- **アナと雪の女王** (Frozen)
+  - *Format:* Feature film (102 min)
+  - *Learning Value:* Popular music; clear character dialogue
+  - *Content:* Sisters' adventure and magical frozen world
+  - *Tip:* Repetitive songs aid vocabulary retention
+
+- **アラジン** (Aladdin)
+  - *Format:* Feature film (90 min)
+  - *Learning Value:* Adventure story; magical elements; character-driven
+  - *Content:* Street urchin and magical lamp adventure
+  - *Music:* Songs provide natural language repetition
+
+- **塔の上のラプンツェル** (Tangled)
+  - *Format:* Feature film (100 min)
+  - *Learning Value:* Coming-of-age; adventure; clear dialogue
+  - *Content:* Long-haired princess escaping tower
+  - *Themes:* Dreams, independence, adventure
+
+- **モアナ** (Moana)
+  - *Format:* Feature film (107 min)
+  - *Learning Value:* Ocean-themed adventure; strong character voice acting
+  - *Content:* Girl's ocean voyage and self-discovery
+  - *Advantage:* Visual beauty; emotional connection to character
+
+- **トイ・ストーリー** (Toy Story) — Original
+  - *Format:* Feature film (81 min)
+  - *Learning Value:* Simple dialogue; relatable friendship themes
+  - *Content:* Toys' secret lives when humans absent
+  - *Perfect for:* Young learners who love toys
+
+- **トイ・ストーリー2** (Toy Story 2)
+  - *Format:* Feature film (92 min)
+  - *Learning Value:* Expanded world; character development; adventure
+  - *Content:* Woody's rescue adventure
+  - *Pace:* Engaging; good balance of action and dialogue
+
+- **ファインディング・ニモ** (Finding Nemo)
+  - *Format:* Feature film (100 min)
+  - *Learning Value:* Ocean journey; emotional father-son story
+  - *Content:* Fish's quest to find his captured son
+  - *Visual Appeal:* Beautiful underwater world holds attention
+
+- **ザ・グッドダイナソー** (The Good Dinosaur)
+  - *Format:* Feature film (93 min)
+  - *Learning Value:* Friendship adventure; simple emotional story
+  - *Content:* Dinosaur and human boy's journey
+  - *Advantage:* Slower pacing than some Pixar films
+
+- **モンスターズ・インク** (Monsters, Inc.)
+  - *Format:* Feature film (92 min)
+  - *Learning Value:* Colorful characters; friendship themes; humor
+  - *Content:* Monsters working at scare factory
+  - *Themes:* Unexpected friendships, protection, family
+
+- **バグズ・ライフ** (A Bug's Life)
+  - *Format:* Feature film (95 min)
+  - *Learning Value:* Ant protagonist; community themes
+  - *Content:* Misfit ant creates circus troupe to fight grasshoppers
+  - *Humor:* Physical comedy translates across languages
+
+- **ニモを探して** (Finding Dory)
+  - *Format:* Feature film (97 min)
+  - *Learning Value:* Sequel to Finding Nemo; similar pacing
+  - *Content:* Blue fish's quest to find her family
+  - *Themes:* Memory, persistence, friendship
+
+- **シンデレラ** (Cinderella - Disney)
+  - *Format:* Feature film (74 min)
+  - *Learning Value:* Classic fairy tale; clear storytelling
+  - *Content:* Girl's magical transformation and royal ball
+  - *Music:* Memorable songs aid memory
+
+- **白雪姫** (Snow White and the Seven Dwarfs)
+  - *Format:* Feature film (83 min)
+  - *Learning Value:* Classic tale; distinct character voices
+  - *Content:* Princess, evil queen, and forest adventure
+  - *Charm:* Dwarfs' simple characterization
+
+- **眠れる森の美女** (Sleeping Beauty)
+  - *Format:* Feature film (75 min)
+  - *Learning Value:* Fairy tale with magical elements
+  - *Content:* Princess cursed; prince's rescue
+  - *Music:* Classic Disney songs
+
+- **ジャングル・ブック** (The Jungle Book)
+  - *Format:* Feature film (78 min)
+  - *Learning Value:* Adventure in animal world; memorable characters
+  - *Content:* Man-cub raised by jungle animals
+  - *Themes:* Growing up, belonging, friendship
+
+- **インサイド・ヘッド** (Inside Out)
+  - *Format:* Feature film (98 min)
+  - *Learning Value:* Emotion vocabulary; character-driven story
+  - *Content:* Emotions personified; girl's emotional journey
+  - *Educational:* Learning about feelings in context
+
+- **ズートピア** (Zootopia)
+  - *Format:* Feature film (108 min)
+  - *Learning Value:* Mystery story; diverse animal characters
+  - *Content:* Rabbit cop and fox investigate crime
+  - *Humor:* Visual gags + clever dialogue
+
+### Picture Book Adaptations & Visual Stories
+
+- **ぐりとぐら** (Guri and Gura)
+  - *Format:* Picture book adaptation/shorts (10-15 min)
+  - *Learning Value:* Classic Japanese picture book; minimal dialogue
+  - *Content:* Two hedgehog friends' simple adventures
+  - *Themes:* Cooking, friendship, nature
+
+- **きんぎょがにげた** (Goldfish Are Escaping)
+  - *Format:* Picture book adaptation (10 min)
+  - *Learning Value:* Search-and-find format; simple narration
+  - *Content:* Boy searches for escaped goldfish
+  - *Interactive:* Viewers look for goldfish on screen
+
+- **はらぺこあおむし** (The Very Hungry Caterpillar)
+  - *Format:* Picture book animation (6 min)
+  - *Learning Value:* Food vocabulary; metamorphosis concept
+  - *Content:* Caterpillar's week-long eating journey
+  - *Perfect for:* Youngest learners; beloved classic
+
+- **わたしのワンピース** (My One-Piece Dress)
+  - *Format:* Picture book animation (10 min)
+  - *Learning Value:* Color and nature vocabulary
+  - *Content:* Girl's magical dress changes with surroundings
+  - *Themes:* Imagination, creativity, nature
+
+- **ねずみくんのチョッキ** (Mice Man's Vest)
+  - *Format:* Picture book adaptation (10 min)
+  - *Learning Value:* Clothing vocabulary; repetitive structure
+  - *Content:* Mouse's sweater borrowed by increasingly large animals
+  - *Perfect for:* Repetition-based learning
+
+### International Shows (Japanese Dub)
+
+- **ブルーイ** (Bluey) — Already listed, worth emphasizing
+  - *Format:* Animated series (7 min episodes)
+  - *For Ages:* 4-6 perfect audience
+  - *Repeat Viewing:* Episodes often repeated; families watch same ones multiple times
+
+- **ペッパ・ピッグ** (Peppa Pig)
+  - *Format:* Animated series (5 min episodes)
+  - *Learning Value:* Preschool family dynamics; simple British content
+  - *Content:* Piglet family's daily adventures
+  - *Perfect for:* Very young; repetitive episodes
+
+- **パディントン** (Paddington - Japanese dub)
+  - *Format:* Animated films
+  - *Learning Value:* British politeness; simple family dynamics
+  - *Content:* Bear in London; heartwarming adventures
+
+- **アーサーとミニモイ** (Arthur and the Minimoys)
+  - *Format:* Animated film (94 min)
+  - *Learning Value:* Fantasy adventure; imaginative world
+  - *Content:* Boy discovers tiny civilization in garden
+  - *Themes:* Adventure, courage, environmental awareness
+
+- **セサミ・ストリート** (Sesame Street - Japanese version, if available)
+  - *Format:* Educational TV series
+  - *Learning Value:* Alphabet, numbers, social skills
+  - *Content:* Muppets and human friends learning together
+  - *Classic:* Timeless educational format
+
+### Other Very Young-Friendly Films
+
+- **メアリと魔女の花** (Mary and the Witch's Flower) — Already listed, emphasizing for young viewers
+  - *Format:* Feature film (102 min)
+  - *For Young Kids:* Magical girl adventure, not too scary
+
+- **ウォーリー** (WALL-E)
+  - *Format:* Feature film (98 min)
+  - *Learning Value:* Minimal dialogue; love story told through actions
+  - *Content:* Robot's lonely world and adventure
+  - *Perfect for:* Visual learners; unique soundtrack
+
+- **ターボ** (Turbo)
+  - *Format:* Feature film (96 min)
+  - *Learning Value:* Dream-focused adventure; inspiring protagonist
+  - *Content:* Snail who dreams of racing
+  - *Themes:* Dreams, determination, individuality
+
+- **ペット** (The Secret Life of Pets)
+  - *Format:* Feature film (87 min)
+  - *Learning Value:* Urban setting; character-driven comedy
+  - *Content:* Pets' secret lives while owners away
+  - *Humor:* Physical comedy; relatable pet situations
+
+- **モンスター・ホテル** (Hotel Transylvania)
+  - *Format:* Feature film (91 min)
+  - *Learning Value:* Monster characters; father-daughter story
+  - *Content:* Dracula's hotel; comedy over scares
+  - *Note:* Monsters are silly, not scary
+
+- **ヒックとドラゴン** (How to Train Your Dragon)
+  - *Format:* Feature film (98 min)
+  - *Learning Value:* Adventure; underdog story; character growth
+  - *Content:* Boy befriends dragon
+  - *Themes:* Understanding, acceptance, courage
+
 ### Studio Ghibli Films (Beginner-Friendly)
 
 - **My Neighbor Totoro** (となりのトトロ)


### PR DESCRIPTION
## Summary
This PR adds a new `VIDEOS.md` document that provides a comprehensive catalog of movies, TV shows, and animated content organized by Japanese language proficiency level (N5 through N4+). The guide is designed to help learners select appropriate video content for their current level and learning goals.

## Key Changes
- **New file:** `VIDEOS.md` - A detailed 831-line video content guide including:
  - **N5 Level (Beginner):** Classic anime series, children's shows, Studio Ghibli films, and international content with Japanese dubs
  - **N5-N4 Transition:** Slice-of-life anime, wholesome series, and live-action dramas
  - **N4+ Level (Intermediate):** Coming-of-age films, complex anime series, and sophisticated narratives
  - **Documentary & Educational Content:** Nature documentaries and language learning shows
  - **Curated Recommendations:** Organized by learning goal (listening practice, cultural immersion, vocabulary building, etc.)
  - **Practical Guidance:** Streaming availability notes and viewing tips

## Notable Implementation Details
- Content is organized hierarchically by difficulty level with clear learning value descriptions for each title
- Each entry includes format, learning value, content summary, and relevant themes/notes
- Recommendations section maps specific content to learner objectives (listening, vocabulary, grammar, motivation)
- Includes both original Japanese content and international content with Japanese dubbing
- Provides practical streaming platform information and evidence-based viewing strategies

https://claude.ai/code/session_01CATFzEZYwW6p9emEqzsbSr