### PR TITLE
Add series support and story relationship management

### DIFF
--- a/scripts/add-series.ts
+++ b/scripts/add-series.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * CLI tool to add new series to the series collection.
+ *
+ * Usage:
+ *   npx tsx scripts/add-series.ts --title "Series Title" --description "Description"
+ *   npx tsx scripts/add-series.ts --help
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+interface SeriesArgs {
+  title?: string;
+  description?: string;
+  level?: string;
+  imageUrl?: string;
+  help?: boolean;
+}
+
+function parseArgs(): SeriesArgs {
+  const args: SeriesArgs = {};
+
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else if (arg === '--title' && i + 1 < process.argv.length) {
+      args.title = process.argv[++i];
+    } else if (arg === '--description' && i + 1 < process.argv.length) {
+      args.description = process.argv[++i];
+    } else if (arg === '--level' && i + 1 < process.argv.length) {
+      args.level = process.argv[++i];
+    } else if (arg === '--imageUrl' && i + 1 < process.argv.length) {
+      args.imageUrl = process.argv[++i];
+    }
+  }
+
+  return args;
+}
+
+function showHelp() {
+  console.log(`
+📺 Add New Series
+
+Usage: npx tsx scripts/add-series.ts [options]
+
+Required Options:
+  --title TEXT          Series title
+  --description TEXT    Series description
+
+Optional Options:
+  --level LEVEL         Difficulty level: n5, n4, n3, etc.
+  --imageUrl URL        URL to series image
+
+  --help                Show this help message
+
+Examples:
+  npx tsx scripts/add-series.ts \\
+    --title "Pokemon Adventure" \\
+    --description "A series of Pokemon adventures"
+
+  npx tsx scripts/add-series.ts \\
+    --title "Naruto" \\
+    --description "Follow Naruto's ninja journey" \\
+    --level n3 \\
+    --imageUrl "https://example.com/naruto.jpg"
+
+After creating a series, add episodes with:
+  npx tsx scripts/add-story.ts \\
+    --title "Pokemon Episode 1" \\
+    --description "The first episode" \\
+    --seriesId SERIES_ID
+`);
+}
+
+function sanitizeFolderName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function generateId(): string {
+  return `series-${Date.now()}`;
+}
+
+async function addSeries(args: SeriesArgs) {
+  // Validate inputs
+  if (!args.title) {
+    console.error('❌ Error: --title is required');
+    console.log('\nUse --help for usage information');
+    process.exit(1);
+  }
+
+  if (!args.description) {
+    console.error('❌ Error: --description is required');
+    console.log('\nUse --help for usage information');
+    process.exit(1);
+  }
+
+  const seriesDir = path.join(process.cwd(), 'src', 'series');
+  const folderName = sanitizeFolderName(args.title);
+  const seriesPath = path.join(seriesDir, folderName);
+
+  // Check if series already exists
+  if (fs.existsSync(seriesPath)) {
+    console.error(`❌ Error: Series "${folderName}" already exists at ${seriesPath}`);
+    process.exit(1);
+  }
+
+  try {
+    // Create series directory if needed
+    if (!fs.existsSync(seriesDir)) {
+      fs.mkdirSync(seriesDir, { recursive: true });
+    }
+
+    // Create series directory
+    fs.mkdirSync(seriesPath, { recursive: true });
+
+    // Create metadata.json
+    const metadata: Record<string, unknown> = {
+      id: generateId(),
+      title: args.title,
+      type: 'series',
+      description: args.description,
+      dateAdded: new Date().toISOString(),
+    };
+
+    if (args.level) metadata.level = args.level;
+    if (args.imageUrl) metadata.imageUrl = args.imageUrl;
+
+    fs.writeFileSync(
+      path.join(seriesPath, 'metadata.json'),
+      JSON.stringify(metadata, null, 2)
+    );
+
+    console.log('\n✅ Series created successfully!\n');
+    console.log(`📁 Location: ${seriesPath}`);
+    console.log(`📺 ID: ${metadata.id}`);
+    console.log(`📖 Title: ${args.title}`);
+    console.log(`\n📄 Files created:`);
+    console.log(`  • metadata.json - Series metadata (no content.md needed)`);
+    console.log(`\n💡 Next steps:`);
+    console.log(`  1. Create episodes with:`);
+    console.log(`     npx tsx scripts/add-story.ts --title "Episode 1" --seriesId ${metadata.id}`);
+    console.log(`  2. Run the tests to verify: npx tsx test-stories-quick.ts`);
+  } catch (error) {
+    console.error(`❌ Error creating series: ${error}`);
+    process.exit(1);
+  }
+}
+
+const args = parseArgs();
+
+if (args.help) {
+  showHelp();
+} else {
+  addSeries(args);
+}

--- a/scripts/add-story.ts
+++ b/scripts/add-story.ts
@@ -16,6 +16,10 @@ interface StoryArgs {
   description?: string;
   level?: string;
   imageUrl?: string;
+  parentId?: string;
+  episodeNumber?: number;
+  variantType?: string;
+  relatedStories?: string;
   help?: boolean;
 }
 
@@ -35,6 +39,14 @@ function parseArgs(): StoryArgs {
       args.level = process.argv[++i];
     } else if (arg === '--imageUrl' && i + 1 < process.argv.length) {
       args.imageUrl = process.argv[++i];
+    } else if (arg === '--parentId' && i + 1 < process.argv.length) {
+      args.parentId = process.argv[++i];
+    } else if (arg === '--episodeNumber' && i + 1 < process.argv.length) {
+      args.episodeNumber = parseInt(process.argv[++i], 10);
+    } else if (arg === '--variantType' && i + 1 < process.argv.length) {
+      args.variantType = process.argv[++i];
+    } else if (arg === '--relatedStories' && i + 1 < process.argv.length) {
+      args.relatedStories = process.argv[++i];
     }
   }
 
@@ -47,16 +59,37 @@ function showHelp() {
 
 Usage: npx tsx scripts/add-story.ts [options]
 
-Options:
-  --title TEXT          Story title (required)
-  --description TEXT    Story description (required)
-  --level LEVEL         Difficulty level: n5, n4, n3, etc. (optional)
-  --imageUrl URL        URL to story image (optional)
+Required Options:
+  --title TEXT          Story title
+  --description TEXT    Story description
+
+Optional Options:
+  --level LEVEL         Difficulty level: n5, n4, n3, etc.
+  --imageUrl URL        URL to story image
+
+Related Stories Options:
+  --parentId ID         Link to parent story (for episodes/variants)
+  --episodeNumber NUM   Episode number for ordering (use with parentId)
+  --variantType TYPE    Type of variant: kanji, hiragana, simplified, full, etc.
+  --relatedStories JSON JSON array of related story objects
+                        Example: '[{"id":"story-123","type":"variant","description":"Kanji version"}]'
+
   --help                Show this help message
 
 Examples:
   npx tsx scripts/add-story.ts --title "My Story" --description "A simple story"
-  npx tsx scripts/add-story.ts --title "Tokyo" --description "A trip to Tokyo" --level n5
+
+  npx tsx scripts/add-story.ts \\
+    --title "浦島太郎 Part 1" \\
+    --description "The first episode of Urashima Taro" \\
+    --parentId "story-parent-id" \\
+    --episodeNumber 1
+
+  npx tsx scripts/add-story.ts \\
+    --title "Art Class (hiragana)" \\
+    --description "Art class with hiragana text" \\
+    --parentId "story-art-class-id" \\
+    --variantType "hiragana"
 `);
 }
 
@@ -86,6 +119,17 @@ async function addStory(args: StoryArgs) {
     process.exit(1);
   }
 
+  let relatedStories: Array<{ id: string; type: string; description?: string }> | undefined;
+  if (args.relatedStories) {
+    try {
+      relatedStories = JSON.parse(args.relatedStories);
+    } catch (error) {
+      console.error('❌ Error: Invalid JSON in --relatedStories');
+      console.log(`Error: ${error}`);
+      process.exit(1);
+    }
+  }
+
   const storiesDir = path.join(process.cwd(), 'src', 'stories');
   const folderName = sanitizeFolderName(args.title);
   const storyPath = path.join(storiesDir, folderName);
@@ -106,15 +150,20 @@ async function addStory(args: StoryArgs) {
     fs.mkdirSync(storyPath, { recursive: true });
 
     // Create metadata.json
-    const metadata = {
+    const metadata: Record<string, unknown> = {
       id: generateId(),
       title: args.title,
       type: 'story',
       description: args.description,
-      ...(args.level && { level: args.level }),
-      ...(args.imageUrl && { imageUrl: args.imageUrl }),
       dateAdded: new Date().toISOString(),
     };
+
+    if (args.level) metadata.level = args.level;
+    if (args.imageUrl) metadata.imageUrl = args.imageUrl;
+    if (args.parentId) metadata.parentId = args.parentId;
+    if (args.episodeNumber !== undefined) metadata.episodeNumber = args.episodeNumber;
+    if (args.variantType) metadata.variantType = args.variantType;
+    if (relatedStories) metadata.relatedStories = relatedStories;
 
     fs.writeFileSync(
       path.join(storyPath, 'metadata.json'),
@@ -138,6 +187,16 @@ async function addStory(args: StoryArgs) {
     console.log(`📁 Location: ${storyPath}`);
     console.log(`📝 ID: ${metadata.id}`);
     console.log(`📖 Title: ${args.title}`);
+
+    if (args.parentId) {
+      if (args.episodeNumber !== undefined) {
+        console.log(`🎬 Episode: ${args.episodeNumber}`);
+      } else if (args.variantType) {
+        console.log(`🔄 Variant: ${args.variantType}`);
+      }
+      console.log(`👁️ Parent ID: ${args.parentId}`);
+    }
+
     console.log(`\n📄 Files created:`);
     console.log(`  • metadata.json - Story metadata`);
     console.log(`  • content.md - Story content (edit this file)`);

--- a/scripts/add-story.ts
+++ b/scripts/add-story.ts
@@ -17,6 +17,7 @@ interface StoryArgs {
   level?: string;
   imageUrl?: string;
   parentId?: string;
+  seriesId?: string;
   episodeNumber?: number;
   variantType?: string;
   relatedStories?: string;
@@ -41,6 +42,8 @@ function parseArgs(): StoryArgs {
       args.imageUrl = process.argv[++i];
     } else if (arg === '--parentId' && i + 1 < process.argv.length) {
       args.parentId = process.argv[++i];
+    } else if (arg === '--seriesId' && i + 1 < process.argv.length) {
+      args.seriesId = process.argv[++i];
     } else if (arg === '--episodeNumber' && i + 1 < process.argv.length) {
       args.episodeNumber = parseInt(process.argv[++i], 10);
     } else if (arg === '--variantType' && i + 1 < process.argv.length) {
@@ -67,8 +70,9 @@ Optional Options:
   --level LEVEL         Difficulty level: n5, n4, n3, etc.
   --imageUrl URL        URL to story image
 
-Related Stories Options:
-  --parentId ID         Link to parent story (for episodes/variants)
+Story Relationships:
+  --parentId ID         Link to parent story (for episodes/variants of a single story)
+  --seriesId ID         Link to a series (for independent episodes in a series like Pokemon)
   --episodeNumber NUM   Episode number for ordering (use with parentId)
   --variantType TYPE    Type of variant: kanji, hiragana, simplified, full, etc.
   --relatedStories JSON JSON array of related story objects
@@ -84,6 +88,11 @@ Examples:
     --description "The first episode of Urashima Taro" \\
     --parentId "story-parent-id" \\
     --episodeNumber 1
+
+  npx tsx scripts/add-story.ts \\
+    --title "Pokemon Episode 1" \\
+    --description "Pikachu appears" \\
+    --seriesId "series-pokemon-id"
 
   npx tsx scripts/add-story.ts \\
     --title "Art Class (hiragana)" \\
@@ -161,6 +170,7 @@ async function addStory(args: StoryArgs) {
     if (args.level) metadata.level = args.level;
     if (args.imageUrl) metadata.imageUrl = args.imageUrl;
     if (args.parentId) metadata.parentId = args.parentId;
+    if (args.seriesId) metadata.seriesId = args.seriesId;
     if (args.episodeNumber !== undefined) metadata.episodeNumber = args.episodeNumber;
     if (args.variantType) metadata.variantType = args.variantType;
     if (relatedStories) metadata.relatedStories = relatedStories;
@@ -194,7 +204,11 @@ async function addStory(args: StoryArgs) {
       } else if (args.variantType) {
         console.log(`🔄 Variant: ${args.variantType}`);
       }
-      console.log(`👁️ Parent ID: ${args.parentId}`);
+      console.log(`👁️ Parent Story ID: ${args.parentId}`);
+    }
+
+    if (args.seriesId) {
+      console.log(`📺 Series ID: ${args.seriesId}`);
     }
 
     console.log(`\n📄 Files created:`);

--- a/src/lib/storyLoader.ts
+++ b/src/lib/storyLoader.ts
@@ -8,6 +8,18 @@ interface RelatedStory {
   description?: string;
 }
 
+interface SeriesMetadata {
+  id: string;
+  title: string;
+  type: 'series';
+  description: string;
+  level?: string;
+  imageUrl?: string;
+  tags?: string[];
+  author?: string;
+  dateAdded?: string;
+}
+
 interface StoryMetadata {
   id: string;
   title: string;
@@ -19,9 +31,52 @@ interface StoryMetadata {
   author?: string;
   dateAdded?: string;
   parentId?: string;
+  seriesId?: string;
   episodeNumber?: number;
   variantType?: 'kanji' | 'hiragana' | 'simplified' | 'full' | string;
   relatedStories?: RelatedStory[];
+}
+
+/**
+ * Load all series from the series directory.
+ * Each series should be in a folder with:
+ * - metadata.json (series metadata only, no content.md needed)
+ *
+ * @returns Array of SeriesMetadata objects
+ */
+export function loadSeriesFromDisk(): SeriesMetadata[] {
+  const seriesDir = path.join(process.cwd(), 'src', 'series');
+
+  // Return empty array if series directory doesn't exist yet
+  if (!fs.existsSync(seriesDir)) {
+    return [];
+  }
+
+  const series: SeriesMetadata[] = [];
+  const seriesFolders = fs.readdirSync(seriesDir).filter(file => {
+    const fullPath = path.join(seriesDir, file);
+    return fs.statSync(fullPath).isDirectory();
+  });
+
+  for (const folder of seriesFolders) {
+    const folderPath = path.join(seriesDir, folder);
+    const metadataPath = path.join(folderPath, 'metadata.json');
+
+    // Skip if metadata file is missing
+    if (!fs.existsSync(metadataPath)) {
+      console.warn(`⚠️  Skipping series ${folder}: missing metadata.json`);
+      continue;
+    }
+
+    try {
+      const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8')) as SeriesMetadata;
+      series.push(metadata);
+    } catch (error) {
+      console.warn(`⚠️  Error loading series from ${folder}:`, error);
+    }
+  }
+
+  return series.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /**
@@ -142,7 +197,7 @@ export function getParentStory(
 
 /**
  * Get all child stories (episodes and variants) for a given story
- * Useful for displaying all parts of a series (e.g., all Pokemon episodes)
+ * Useful for displaying all parts of a single story (e.g., Urashima Taro parts 1-3)
  * @param storyId The parent story ID
  * @param storiesWithMetadata All stories with their metadata
  * @returns Array of child stories sorted by episode number, variants last
@@ -177,4 +232,22 @@ export function getChildren(
   });
 
   return children.map(c => ({ story: c.story, metadata: c.metadata }));
+}
+
+/**
+ * Get all stories in a series
+ * Useful for displaying all episodes of a series (e.g., all 10 Pokemon episodes)
+ * @param seriesId The series ID
+ * @param storiesWithMetadata All stories with their metadata
+ * @returns Array of stories in the series
+ */
+export function getSeriesStories(
+  seriesId: string,
+  storiesWithMetadata: Array<{ story: Content; metadata: StoryMetadata }>
+) {
+  const seriesStories = storiesWithMetadata
+    .filter(item => item.metadata.seriesId === seriesId)
+    .map(item => item.story);
+
+  return seriesStories;
 }

--- a/src/lib/storyLoader.ts
+++ b/src/lib/storyLoader.ts
@@ -2,6 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import { Content } from '../data/content';
 
+interface RelatedStory {
+  id: string;
+  type: 'episode' | 'variant' | 'series';
+  description?: string;
+}
+
 interface StoryMetadata {
   id: string;
   title: string;
@@ -12,6 +18,10 @@ interface StoryMetadata {
   tags?: string[];
   author?: string;
   dateAdded?: string;
+  parentId?: string;
+  episodeNumber?: number;
+  variantType?: 'kanji' | 'hiragana' | 'simplified' | 'full' | string;
+  relatedStories?: RelatedStory[];
 }
 
 /**
@@ -65,4 +75,67 @@ export function loadStoriesFromDisk(): Content[] {
   }
 
   return stories.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Find related stories by ID
+ * @param storyId The story ID to find relations for
+ * @param allStories All loaded stories with metadata
+ * @returns Object with episodes, variants, and series related to this story
+ */
+export function findRelatedStories(
+  storyId: string,
+  storiesWithMetadata: Array<{ story: Content; metadata: StoryMetadata }>
+) {
+  const story = storiesWithMetadata.find(s => s.story.id === storyId);
+  if (!story) return { episodes: [], variants: [], series: [] };
+
+  const episodes: Content[] = [];
+  const variants: Content[] = [];
+  const series: Content[] = [];
+
+  const mainMetadata = story.metadata;
+
+  for (const item of storiesWithMetadata) {
+    if (item.story.id === storyId) continue;
+
+    const meta = item.metadata;
+
+    if (meta.parentId === storyId) {
+      if (meta.variantType) {
+        variants.push(item.story);
+      } else if (meta.episodeNumber !== undefined) {
+        episodes.push(item.story);
+      }
+    }
+
+    if (mainMetadata.relatedStories?.some(r => r.id === item.story.id)) {
+      if (meta.variantType) {
+        variants.push(item.story);
+      } else {
+        series.push(item.story);
+      }
+    }
+  }
+
+  episodes.sort((a, b) => {
+    const aNum = storiesWithMetadata.find(s => s.story.id === a.id)?.metadata.episodeNumber ?? 0;
+    const bNum = storiesWithMetadata.find(s => s.story.id === b.id)?.metadata.episodeNumber ?? 0;
+    return aNum - bNum;
+  });
+
+  return { episodes, variants, series };
+}
+
+/**
+ * Get parent story if this is an episode or variant
+ */
+export function getParentStory(
+  storyId: string,
+  storiesWithMetadata: Array<{ story: Content; metadata: StoryMetadata }>
+) {
+  const story = storiesWithMetadata.find(s => s.story.id === storyId);
+  if (!story?.metadata.parentId) return null;
+
+  return storiesWithMetadata.find(s => s.story.id === story.metadata.parentId)?.story ?? null;
 }

--- a/src/lib/storyLoader.ts
+++ b/src/lib/storyLoader.ts
@@ -139,3 +139,42 @@ export function getParentStory(
 
   return storiesWithMetadata.find(s => s.story.id === story.metadata.parentId)?.story ?? null;
 }
+
+/**
+ * Get all child stories (episodes and variants) for a given story
+ * Useful for displaying all parts of a series (e.g., all Pokemon episodes)
+ * @param storyId The parent story ID
+ * @param storiesWithMetadata All stories with their metadata
+ * @returns Array of child stories sorted by episode number, variants last
+ */
+export function getChildren(
+  storyId: string,
+  storiesWithMetadata: Array<{ story: Content; metadata: StoryMetadata }>
+) {
+  const children: Array<{ story: Content; metadata: StoryMetadata; isVariant: boolean }> = [];
+
+  for (const item of storiesWithMetadata) {
+    if (item.metadata.parentId === storyId) {
+      children.push({
+        ...item,
+        isVariant: !!item.metadata.variantType,
+      });
+    }
+  }
+
+  // Sort: episodes first (by episode number), then variants
+  children.sort((a, b) => {
+    if (a.isVariant && !b.isVariant) return 1;
+    if (!a.isVariant && b.isVariant) return -1;
+
+    if (!a.isVariant && !b.isVariant) {
+      const aNum = a.metadata.episodeNumber ?? 0;
+      const bNum = b.metadata.episodeNumber ?? 0;
+      return aNum - bNum;
+    }
+
+    return a.story.title.localeCompare(b.story.title);
+  });
+
+  return children.map(c => ({ story: c.story, metadata: c.metadata }));
+}

--- a/src/lib/storyLoader.ts
+++ b/src/lib/storyLoader.ts
@@ -30,7 +30,10 @@ interface StoryMetadata {
   tags?: string[];
   author?: string;
   dateAdded?: string;
+  // Relationships - use ONE of these, not both:
+  // Use parentId for episodes/variants of a single story (e.g., Urashima Taro Part 1, Part 2)
   parentId?: string;
+  // Use seriesId for independent episodes grouped into a series (e.g., Pokemon Episode 1, 2, 3)
   seriesId?: string;
   episodeNumber?: number;
   variantType?: 'kanji' | 'hiragana' | 'simplified' | 'full' | string;
@@ -196,8 +199,9 @@ export function getParentStory(
 }
 
 /**
- * Get all child stories (episodes and variants) for a given story
- * Useful for displaying all parts of a single story (e.g., Urashima Taro parts 1-3)
+ * Get all child stories (episodes and variants) for a given story.
+ * Use this for stories split into parts via parentId (e.g., Urashima Taro Part 1, Part 2).
+ * NOT for series episodes - use getSeriesStories() instead.
  * @param storyId The parent story ID
  * @param storiesWithMetadata All stories with their metadata
  * @returns Array of child stories sorted by episode number, variants last
@@ -235,8 +239,9 @@ export function getChildren(
 }
 
 /**
- * Get all stories in a series
- * Useful for displaying all episodes of a series (e.g., all 10 Pokemon episodes)
+ * Get all stories in a series.
+ * Use this for independent episodes grouped into a series via seriesId (e.g., Pokemon Episode 1, 2, 3).
+ * NOT for story parts - use getChildren() instead.
  * @param seriesId The series ID
  * @param storiesWithMetadata All stories with their metadata
  * @returns Array of stories in the series


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive system for managing story relationships and series in the content library. It adds support for grouping stories into series, creating story variants (kanji/hiragana versions), and organizing multi-part stories with parent-child relationships.

## Key Changes

### New Data Structures
- Added `SeriesMetadata` interface for managing series collections
- Extended `StoryMetadata` with relationship fields:
  - `parentId`: Links episodes/variants to a parent story
  - `seriesId`: Links independent episodes to a series
  - `episodeNumber`: Orders episodes within a parent story
  - `variantType`: Identifies variant types (kanji, hiragana, simplified, etc.)
  - `relatedStories`: Flexible array for cross-story references

### New Functions in `storyLoader.ts`
- `loadSeriesFromDisk()`: Loads series metadata from the `src/series` directory
- `findRelatedStories()`: Discovers related episodes, variants, and series for a given story
- `getParentStory()`: Retrieves the parent story for episodes/variants
- `getChildren()`: Gets all child stories (episodes and variants) for a parent, sorted appropriately
- `getSeriesStories()`: Retrieves all stories belonging to a series

### New CLI Tool: `scripts/add-series.ts`
- Interactive script to create new series with metadata
- Generates unique series IDs and creates directory structure
- Supports optional fields: level, imageUrl
- Provides guidance for adding episodes to the series

### Enhanced `scripts/add-story.ts`
- Added support for all new relationship fields via CLI arguments
- New flags: `--parentId`, `--seriesId`, `--episodeNumber`, `--variantType`, `--relatedStories`
- Improved help documentation with examples for different story types
- Better output formatting showing relationship information

## Implementation Details
- Series are stored in `src/series/{series-name}/metadata.json` (no content.md required)
- Stories can use either `parentId` (for multi-part stories) OR `seriesId` (for series episodes), not both
- Episode sorting is automatic based on `episodeNumber`
- Variants are sorted after episodes and by title
- All functions handle missing data gracefully with sensible defaults

https://claude.ai/code/session_018miAanYH5T6AkaWRVszunF