### PR TITLE
Implement chunked batch extraction to handle large payloads

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -562,7 +562,7 @@ async function startServer() {
   const app = express();
   const PORT = 3000;
 
-  app.use(express.json());
+  app.use(express.json({ limit: '50mb' }));
 
   // Periodically save caches to disk (every 30 seconds if changed)
   setInterval(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,45 +119,52 @@ export default function App() {
         const texts = ALL_CONTENT.map(c => ({ id: c.id, text: c.text }));
         console.log(`[App] Starting background vocabulary extraction for ${texts.length} stories`);
 
-        const res = await fetch("/api/batch-extract", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ texts })
-        });
-
-        if (!res.ok) {
-          console.warn(`[App] Batch extract failed with status ${res.status}`);
-          return;
-        }
-
-        const results = await res.json();
-        const successful = results.filter((r: any) => !r.error);
-        console.log(`[App] Background extraction complete: ${successful.length}/${results.length} stories processed`);
-
-        // Update contentVocab state with extracted vocabulary
+        const CHUNK_SIZE = 20;
         const newVocab: Record<string, any[]> = {};
-        let addedCount = 0;
-        for (const result of results) {
-          if (result.words && Array.isArray(result.words)) {
-            // Apply WaniKani multipliers if available
-            let words = result.words;
-            if (wkData) {
-              words = applyWaniKaniToWords(words, wkData);
+        let totalProcessed = 0;
+
+        // Process in chunks to avoid payload size limits
+        for (let i = 0; i < texts.length; i += CHUNK_SIZE) {
+          const chunk = texts.slice(i, i + CHUNK_SIZE);
+          console.log(`[App] Processing chunk ${Math.floor(i / CHUNK_SIZE) + 1}/${Math.ceil(texts.length / CHUNK_SIZE)}`);
+
+          const res = await fetch("/api/batch-extract", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ texts: chunk })
+          });
+
+          if (!res.ok) {
+            console.warn(`[App] Batch extract chunk failed with status ${res.status}`);
+            continue;
+          }
+
+          const results = await res.json();
+          const successful = results.filter((r: any) => !r.error);
+
+          // Accumulate results
+          for (const result of results) {
+            if (result.words && Array.isArray(result.words)) {
+              let words = result.words;
+              if (wkData) {
+                words = applyWaniKaniToWords(words, wkData);
+              }
+              newVocab[result.id] = words;
+              totalProcessed++;
             }
-            newVocab[result.id] = words;
-            addedCount++;
+          }
+
+          // Update UI incrementally as chunks complete
+          if (Object.keys(newVocab).length > 0) {
+            setContentVocab(prev => {
+              const updated = { ...prev, ...newVocab };
+              localStorage.setItem('contentVocab', JSON.stringify(updated));
+              return updated;
+            });
           }
         }
 
-        if (addedCount > 0) {
-          setContentVocab(prev => {
-            const updated = { ...prev, ...newVocab };
-            localStorage.setItem('contentVocab', JSON.stringify(updated));
-            return updated;
-          });
-          console.log(`[App] Updated UI with vocabulary for ${addedCount} stories`);
-        }
-
+        console.log(`[App] Background extraction complete: ${totalProcessed}/${texts.length} stories processed`);
         setBatchExtractionAttempted(true);
       } catch (e) {
         console.error(`[App] Background extraction error:`, e);


### PR DESCRIPTION
## Summary
This PR improves the background vocabulary extraction process to handle large datasets by processing content in chunks rather than sending all texts in a single request. It also increases the server's JSON payload limit to accommodate larger individual chunks.

## Key Changes
- **Chunked processing**: Split vocabulary extraction into 20-item chunks to avoid payload size limits and improve reliability
- **Incremental UI updates**: Update the UI as each chunk completes rather than waiting for all processing to finish
- **Server payload limit**: Increased Express JSON body limit from default (100kb) to 50mb to handle larger chunk payloads
- **Better error handling**: Continue processing subsequent chunks if one fails, rather than aborting the entire batch
- **Improved logging**: Added chunk progress tracking to monitor extraction progress

## Implementation Details
- Chunks are processed sequentially with a fixed size of 20 items per request
- Vocabulary results are accumulated in `newVocab` and the UI is updated after each successful chunk
- WaniKani multipliers are still applied to words as they're processed
- Total processed count is tracked and logged at the end for verification

https://claude.ai/code/session_01G4odNovg7XJx1Av32hfXmD