### PR TITLE
Improve cache loading and dictionary lookup performance

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -215,7 +215,9 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   let cacheHits = 0;
   let cacheMisses = 0;
   const results = [];
+  const processedWords: string[] = [];
   for (const [wordStr, baseForm] of validWords) {
+    processedWords.push(wordStr);
     const start = Date.now();
     // Try to look up using baseForm first (for conjugated verbs), then fall back to wordStr
     const cacheHadBase = wordsCache.has(baseForm);
@@ -334,6 +336,7 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
     results.push(morphemeData);
   }
 
+  console.log(`[API] Words processed: [${processedWords.join(', ')}] (${processedWords.length} total)`);
   console.log(`[API] Cache stats: ${cacheHits} hits, ${cacheMisses} misses (${Math.round(cacheHits / (cacheHits + cacheMisses) * 100)}% hit rate)`);
 
   return results;
@@ -368,7 +371,9 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
   let cacheHits = 0;
   let cacheMisses = 0;
   const results = [];
+  const processedWords: string[] = [];
   for (const [wordStr, baseForm] of validWords) {
+    processedWords.push(wordStr);
     const start = Date.now();
     // Try to look up using baseForm first (for conjugated verbs), then fall back to wordStr
     const cacheHadBase = wordsCache.has(baseForm);
@@ -464,6 +469,7 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
     results.push(morphemeData);
   }
 
+  console.log(`[API] Words processed: [${processedWords.join(', ')}] (${processedWords.length} total)`);
   console.log(`[API] Cache stats: ${cacheHits} hits, ${cacheMisses} misses (${Math.round(cacheHits / (cacheHits + cacheMisses) * 100)}% hit rate)`);
 
   return results;

--- a/server.ts
+++ b/server.ts
@@ -132,45 +132,54 @@ const dictionaryReady = (async () => {
   }
   console.log('[Dictionary] Initialization complete');
 
-  // Load decompressed cache files if they exist
-  const wordCacheFile = path.join(__dirname, '.word-cache.json');
-  const jishoCacheFile = path.join(__dirname, '.jisho-cache.json');
-
-  if (fs.existsSync(wordCacheFile)) {
-    try {
-      const cacheStart = Date.now();
-      const data = JSON.parse(fs.readFileSync(wordCacheFile, 'utf-8'));
-      for (const [word, entries] of Object.entries(data)) {
-        if (!wordsCache.has(word)) {
-          wordsCache.set(word, entries as any);
-        }
-      }
-      console.log(`[Cache] Loaded ${Object.keys(data).length} words from .word-cache.json (${Date.now() - cacheStart}ms)`);
-    } catch (e: any) {
-      console.warn('[Cache] Failed to load word cache:', e.message);
-    }
-  }
-
-  if (fs.existsSync(jishoCacheFile)) {
-    try {
-      const cacheStart = Date.now();
-      const data = JSON.parse(fs.readFileSync(jishoCacheFile, 'utf-8'));
-      for (const [word, result] of Object.entries(data)) {
-        if (!jishoCache.has(word)) {
-          jishoCache.set(word, result);
-        }
-      }
-      console.log(`[Cache] Loaded ${Object.keys(data).length} Jisho entries from .jisho-cache.json (${Date.now() - cacheStart}ms)`);
-    } catch (e: any) {
-      console.warn('[Cache] Failed to load Jisho cache:', e.message);
-    }
-  }
-
   // Pre-load all cached words from database into memory for fast lookups
   const preloadStart = Date.now();
   wordsCache.preload();
   const preloadTime = Date.now() - preloadStart;
   console.log(`[Server] Pre-loaded ${wordsCache.size} words and ${jishoCache.size} Jisho entries from database (${preloadTime}ms)`);
+
+  // Load decompressed cache files in the background (don't block server startup)
+  const loadCachesInBackground = async () => {
+    const wordCacheFile = path.join(__dirname, '.word-cache.json');
+    const jishoCacheFile = path.join(__dirname, '.jisho-cache.json');
+
+    if (fs.existsSync(jishoCacheFile)) {
+      try {
+        const cacheStart = Date.now();
+        const data = JSON.parse(fs.readFileSync(jishoCacheFile, 'utf-8'));
+        for (const [word, result] of Object.entries(data)) {
+          if (!jishoCache.has(word)) {
+            jishoCache.set(word, result);
+          }
+        }
+        console.log(`[Cache] Loaded ${Object.keys(data).length} Jisho entries from .jisho-cache.json (${Date.now() - cacheStart}ms)`);
+      } catch (e: any) {
+        console.warn('[Cache] Failed to load Jisho cache:', e.message);
+      }
+    }
+
+    // Load word cache in background (this is large, ~390MB)
+    if (fs.existsSync(wordCacheFile)) {
+      try {
+        const cacheStart = Date.now();
+        console.log('[Cache] Starting to load word cache (this may take a minute)...');
+        const data = JSON.parse(fs.readFileSync(wordCacheFile, 'utf-8'));
+        let loadedCount = 0;
+        for (const [word, entries] of Object.entries(data)) {
+          if (!wordsCache.has(word)) {
+            wordsCache.set(word, entries as any);
+            loadedCount++;
+          }
+        }
+        console.log(`[Cache] Loaded ${loadedCount} words from .word-cache.json (${Date.now() - cacheStart}ms)`);
+      } catch (e: any) {
+        console.warn('[Cache] Failed to load word cache:', e.message);
+      }
+    }
+  };
+
+  // Load caches in background so server isn't blocked
+  loadCachesInBackground().catch(e => console.error('[Cache] Background loading error:', e));
 })();
 
 

--- a/server.ts
+++ b/server.ts
@@ -132,6 +132,40 @@ const dictionaryReady = (async () => {
   }
   console.log('[Dictionary] Initialization complete');
 
+  // Load decompressed cache files if they exist
+  const wordCacheFile = path.join(__dirname, '.word-cache.json');
+  const jishoCacheFile = path.join(__dirname, '.jisho-cache.json');
+
+  if (fs.existsSync(wordCacheFile)) {
+    try {
+      const cacheStart = Date.now();
+      const data = JSON.parse(fs.readFileSync(wordCacheFile, 'utf-8'));
+      for (const [word, entries] of Object.entries(data)) {
+        if (!wordsCache.has(word)) {
+          wordsCache.set(word, entries as any);
+        }
+      }
+      console.log(`[Cache] Loaded ${Object.keys(data).length} words from .word-cache.json (${Date.now() - cacheStart}ms)`);
+    } catch (e: any) {
+      console.warn('[Cache] Failed to load word cache:', e.message);
+    }
+  }
+
+  if (fs.existsSync(jishoCacheFile)) {
+    try {
+      const cacheStart = Date.now();
+      const data = JSON.parse(fs.readFileSync(jishoCacheFile, 'utf-8'));
+      for (const [word, result] of Object.entries(data)) {
+        if (!jishoCache.has(word)) {
+          jishoCache.set(word, result);
+        }
+      }
+      console.log(`[Cache] Loaded ${Object.keys(data).length} Jisho entries from .jisho-cache.json (${Date.now() - cacheStart}ms)`);
+    } catch (e: any) {
+      console.warn('[Cache] Failed to load Jisho cache:', e.message);
+    }
+  }
+
   // Pre-load all cached words from database into memory for fast lookups
   const preloadStart = Date.now();
   wordsCache.preload();
@@ -226,8 +260,30 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
           };
         }
       } else {
-        // Fall back to batch cache or dictionary lookup
-        dictResult = kanaLookupCache?.get(wordStr) ?? await dictionary.lookup(wordStr);
+        // Try batch cache first, then dictionary lookup
+        dictResult = kanaLookupCache?.get(wordStr);
+        if (!dictResult) {
+          dictResult = await dictionary.lookup(wordStr);
+          // Save to batch cache for reuse within this request
+          if (dictResult) {
+            kanaLookupCache?.set(wordStr, dictResult);
+          }
+        }
+
+        // Save dictionary result to persistent cache for future requests
+        if (dictResult) {
+          const entry: DictionaryEntry = {
+            meanings: (dictResult.meanings || [dictResult.meaning])
+              .filter(Boolean)
+              .map((m: string) => ({ glosses: [m] })),
+            variants: [{
+              pronounced: dictResult.reading || wordStr,
+              written: wordStr,
+              priorities: []
+            }]
+          };
+          wordsCache.set(wordStr, [entry]);
+        }
       }
 
       if (dictResult) {

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -424,12 +424,6 @@ export class JmnedictDictionary implements Dictionary {
     // Cache the result (including null results to avoid repeated lookups)
     this.cache.set(word, result);
 
-    if (result) {
-      console.log(`[Dictionary.JMnedict] Found "${word}": ${result.meaning}`);
-    } else {
-      console.log(`[Dictionary.JMnedict] No entry for "${word}"`);
-    }
-
     return result;
   }
 }
@@ -504,18 +498,19 @@ export class DictionaryManager {
   async lookup(word: string): Promise<WordLookupResult | null> {
     if (!this.primary) return null;
 
-    // For pure hiragana words, try JMnedict first (before other fallbacks)
-    // This gives priority to proper nouns for hiragana-only words
+    // Try primary dictionary first (Jisho API cache is fastest)
+    const result = await this.primary.lookup(word);
+    if (result) return result;
+
+    // For pure hiragana words, try JMnedict next (proper nouns)
+    // This is after primary cache, so frequent hiragana hits the cache
     const isPureHiragana = /^[ぁ-ん]+$/.test(word);
     if (isPureHiragana && this.fallback1) {
       const jmnedictResult = await this.fallback1.lookup(word);
       if (jmnedictResult) return jmnedictResult;
     }
 
-    const result = await this.primary.lookup(word);
-    if (result) return result;
-
-    // Try remaining fallback chain: Jisho API → KanjiData
+    // Try remaining fallback chain: KanjiData
     if (this.fallback2) {
       const result2 = await this.fallback2.lookup(word);
       if (result2) return result2;


### PR DESCRIPTION
## Summary
This PR enhances the caching system and dictionary lookup logic to improve server startup time and request performance. It introduces background cache loading, persistent word cache storage, and optimizes the dictionary lookup chain.

## Key Changes

- **Background cache loading**: Moved decompressed cache file loading to run asynchronously after server startup, preventing the large word cache (~390MB) from blocking initialization
- **Persistent word cache**: Dictionary lookup results are now saved to the persistent `wordsCache` for future requests, reducing repeated lookups
- **Improved lookup chain**: Reordered dictionary lookup priority to check the primary cache first (fastest), then JMnedict for hiragana words, then remaining fallbacks
- **Enhanced logging**: Added detailed logging of processed words and improved cache statistics tracking in both `processText` and `processTextWithTokens` functions
- **Batch cache optimization**: Explicit batch cache checking and population within request processing to improve cache reuse
- **Reduced noise**: Removed verbose per-lookup logging from JMnedict dictionary to reduce console spam

## Implementation Details

The background cache loading uses `loadCachesInBackground()` which:
- Loads Jisho cache entries first (smaller, faster)
- Loads word cache in background (large file, may take ~1 minute)
- Only adds entries not already in cache to avoid duplicates
- Includes error handling and timing information

Dictionary lookup now follows this priority:
1. Primary dictionary (Jisho API cache) - fastest
2. JMnedict (for pure hiragana words) - proper nouns
3. Remaining fallbacks (KanjiData)

This ensures frequently accessed words hit the cache quickly while still supporting proper noun lookups for hiragana-only terms.

https://claude.ai/code/session_019R4pqGq557vJS8oEgPvkPt