### PR TITLE
Remove debug console.log statements from dictionary classes

### DIFF
--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -39,7 +39,6 @@ export class KanjiDataDictionary implements Dictionary {
     }
     const entries = this.searchWords(word) as any[];
     if (!entries || entries.length === 0) {
-      console.log(`[Dictionary.KanjiData] No entries for "${word}"`);
       return null;
     }
 
@@ -141,7 +140,6 @@ export class JishoApiDictionary implements Dictionary {
     // Check cache first
     if (this.cache.has(word)) {
       const cached = this.cache.get(word);
-      console.log(`[Dictionary.Jisho] Cache hit for "${word}": ${cached?.meaning || 'null'}`);
       return cached || null;
     }
 


### PR DESCRIPTION
## Summary
Removed debug logging statements from the dictionary implementation to clean up console output in production code.

## Changes
- Removed debug log from `KanjiDataDictionary.search()` that logged when no entries were found for a word
- Removed debug log from `JishoApiDictionary.search()` that logged cache hits with word and meaning information

## Details
These console.log statements were used for debugging purposes during development but are not necessary for the production codebase. Removing them reduces noise in console output and follows best practices for clean production code.

https://claude.ai/code/session_01RUMnhNHfAUSR8vefW3yCCd