### PR TITLE
Add persistent content-word storage and optimize batch extraction

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -784,6 +784,40 @@ async function startServer() {
       const foundCount = Array.from(kanaLookupCache.values()).filter(v => v !== null).length;
       console.log(`[API] /api/batch-extract: Step 3 - Kana lookup completed in ${lookupTime}ms (${foundCount}/${uniqueKanaWords.size} found)`);
 
+      // Pre-populate wordsCache with kanji/mixed word lookups, deduplicated across all items
+      const kanjiPreloadStart = Date.now();
+      const uniqueKanjiWords = new Map<string, string>(); // surface -> baseForm
+      for (const item of tokenizedBatch) {
+        if (!item.tokens) continue;
+        for (const token of item.tokens) {
+          const surface = token.surface;
+          if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+          const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
+          const isPureKatakana = /^[ァ-ヴー]+$/.test(surface);
+          if (!isPureHiragana && !isPureKatakana && !uniqueKanjiWords.has(surface)) {
+            uniqueKanjiWords.set(surface, token.baseForm);
+          }
+        }
+      }
+      let kanjiPreloaded = 0;
+      for (const [surface, baseForm] of uniqueKanjiWords) {
+        if (!wordsCache.has(baseForm)) {
+          const entries = getCachedDictionaryEntries(baseForm);
+          if (entries.length > 0) {
+            wordsCache.set(baseForm, entries);
+            kanjiPreloaded++;
+          }
+        }
+        if (surface !== baseForm && !wordsCache.has(surface)) {
+          const entries = getCachedDictionaryEntries(surface);
+          if (entries.length > 0) {
+            wordsCache.set(surface, entries);
+          }
+        }
+      }
+      const kanjiPreloadTime = Date.now() - kanjiPreloadStart;
+      console.log(`[API] /api/batch-extract: Step 3.5 - Pre-loaded ${kanjiPreloaded}/${uniqueKanjiWords.size} kanji words in ${kanjiPreloadTime}ms`);
+
       // Process texts with pre-looked-up kana cache
       const processStart = Date.now();
       const results = await Promise.all(

--- a/server.ts
+++ b/server.ts
@@ -618,6 +618,157 @@ async function processStoryText(text: string) {
   return enrichedTokens;
 }
 
+type BatchResult = { id: string; words?: any[]; elapsed?: number; error?: string };
+
+async function runBatchExtract(texts: { id: string; text: string }[]): Promise<BatchResult[]> {
+  const batchStart = Date.now();
+  console.log(`[API] /api/batch-extract: Processing ${texts.length} items (cache: ${wordsCache.size} words)`);
+
+  // Sort by text length (shorter first) for faster initial cache warmup
+  const sortedTexts = [...texts].sort((a, b) => (a.text?.length ?? 0) - (b.text?.length ?? 0));
+
+  // Step 1: Tokenize all texts concurrently
+  const tokenStart = Date.now();
+  const tokenizedBatch = await Promise.all(
+    sortedTexts.map(async (item) => {
+      if (!item.text || typeof item.text !== "string") return { ...item, tokens: null };
+      try {
+        const tokens = await tokenizer!.segment(item.text);
+        return { ...item, tokens };
+      } catch (e) {
+        console.error(`[API] Tokenization error for item ${item.id}:`, e instanceof Error ? e.message : String(e));
+        return { ...item, tokens: null };
+      }
+    })
+  );
+  console.log(`[API] /api/batch-extract: Step 1 - Tokenization completed in ${Date.now() - tokenStart}ms`);
+
+  // Collect unique kana-only words from all texts
+  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
+  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
+
+  const collectStart = Date.now();
+  const uniqueKanaWords = new Set<string>();
+  for (const item of tokenizedBatch) {
+    if (!item.tokens) continue;
+    for (const token of item.tokens) {
+      const surface = token.surface;
+      if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+      if (/^[ぁ-ん]+$/.test(surface) || /^[ァ-ヴー]+$/.test(surface)) {
+        uniqueKanaWords.add(surface);
+      }
+    }
+  }
+  console.log(`[API] /api/batch-extract: Step 2 - Found ${uniqueKanaWords.size} unique kana words in ${Date.now() - collectStart}ms`);
+
+  // Step 3: Look up kana words with concurrency limit
+  const lookupStart = Date.now();
+  const kanaLookupCache = new Map<string, any>();
+  if (dictionary && uniqueKanaWords.size > 0) {
+    const words = Array.from(uniqueKanaWords);
+    const concurrencyLimit = 5;
+    const kanaResults: { word: string; result: any }[] = [];
+    let activeCount = 0;
+    let index = 0;
+
+    await new Promise<void>((resolve, reject) => {
+      const processNext = async () => {
+        try {
+          if (index >= words.length && activeCount === 0) { resolve(); return; }
+          if (activeCount < concurrencyLimit && index < words.length) {
+            const word = words[index++];
+            activeCount++;
+            try {
+              const result = await dictionary!.lookup(word);
+              kanaResults.push({ word, result });
+            } catch (e) {
+              console.error(`[API] Kana lookup error for "${word}":`, e instanceof Error ? e.message : String(e));
+              kanaResults.push({ word, result: null });
+            } finally {
+              activeCount--;
+              await processNext();
+            }
+          } else if (index < words.length) {
+            setTimeout(() => processNext().catch(reject), 10);
+          }
+        } catch (err) { reject(err); }
+      };
+      for (let i = 0; i < concurrencyLimit; i++) processNext().catch(reject);
+    });
+
+    for (const { word, result } of kanaResults) {
+      kanaLookupCache.set(word, result);
+      if (result) {
+        wordsCache.set(word, [{
+          meanings: [{ glosses: [result.meaning || 'Unknown'] }],
+          variants: [{ pronounced: result.reading || word, written: word }]
+        } as any]);
+      }
+    }
+  }
+  const foundCount = Array.from(kanaLookupCache.values()).filter(v => v !== null).length;
+  console.log(`[API] /api/batch-extract: Step 3 - Kana lookup completed in ${Date.now() - lookupStart}ms (${foundCount}/${uniqueKanaWords.size} found)`);
+
+  // Step 3.5: Pre-populate wordsCache with kanji/mixed words, deduplicated across all items
+  const kanjiPreloadStart = Date.now();
+  const uniqueKanjiWords = new Map<string, string>(); // surface -> baseForm
+  for (const item of tokenizedBatch) {
+    if (!item.tokens) continue;
+    for (const token of item.tokens) {
+      const surface = token.surface;
+      if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
+      if (!/^[ぁ-ん]+$/.test(surface) && !/^[ァ-ヴー]+$/.test(surface) && !uniqueKanjiWords.has(surface)) {
+        uniqueKanjiWords.set(surface, token.baseForm);
+      }
+    }
+  }
+  let kanjiPreloaded = 0;
+  for (const [surface, baseForm] of uniqueKanjiWords) {
+    if (!wordsCache.has(baseForm)) {
+      const entries = getCachedDictionaryEntries(baseForm);
+      if (entries.length > 0) { wordsCache.set(baseForm, entries); kanjiPreloaded++; }
+    }
+    if (surface !== baseForm && !wordsCache.has(surface)) {
+      const entries = getCachedDictionaryEntries(surface);
+      if (entries.length > 0) wordsCache.set(surface, entries);
+    }
+  }
+  console.log(`[API] /api/batch-extract: Step 3.5 - Pre-loaded ${kanjiPreloaded}/${uniqueKanjiWords.size} kanji words in ${Date.now() - kanjiPreloadStart}ms`);
+
+  // Step 4: Process each text using the pre-built caches
+  const processStart = Date.now();
+  const results: BatchResult[] = await Promise.all(
+    tokenizedBatch.map(async (item) => {
+      const { id, text, tokens } = item;
+      if (!text || typeof text !== "string") return { id, error: "No text" };
+      if (!tokens) return { id, error: "Tokenization failed" };
+      const start = Date.now();
+      try {
+        const words = await processTextWithTokens(text, tokens, kanaLookupCache);
+        const elapsed = Date.now() - start;
+        console.log(`[API] batch-extract[${id}]: ${words.length} words in ${elapsed}ms`);
+        return { id, words, elapsed };
+      } catch (e: any) {
+        console.error(`[API] batch-extract[${id}]: Error:`, e instanceof Error ? e.message : String(e));
+        return { id, error: e instanceof Error ? e.message : String(e) };
+      }
+    })
+  );
+  console.log(`[API] /api/batch-extract: Step 4 - Text processing completed in ${Date.now() - processStart}ms`);
+
+  // Persist content-word associations
+  for (const result of results) {
+    if (result.words && Array.isArray(result.words)) {
+      contentWordsStore.setContentWords(result.id, result.words);
+    }
+  }
+  saveDatabase();
+
+  console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words (total: ${Date.now() - batchStart}ms)`);
+  return results;
+}
+
 async function startServer() {
   // Wait for tokenizer and dictionary to be ready before starting server
   await tokenizerReady;
@@ -627,11 +778,6 @@ async function startServer() {
   const PORT = 3000;
 
   app.use(express.json({ limit: '50mb' }));
-
-  // Periodically save database to disk (every 30 seconds)
-  setInterval(() => {
-    saveDatabase();
-  }, 30000);
 
   // Log only non-asset requests to reduce noise
   app.use((req, _res, next) => {
@@ -672,193 +818,15 @@ async function startServer() {
   });
 
   app.post("/api/batch-extract", async (req, res) => {
-    const batchStart = Date.now();
     try {
       const { texts } = req.body;
       if (!Array.isArray(texts)) {
         return res.status(400).json({ error: "texts must be an array" });
       }
-
-      console.log(`[API] /api/batch-extract: Processing ${texts.length} items (cache: ${wordsCache.size} words)`);
-
-      // Sort by text length (shorter first) for faster initial cache warmup
-      const sortedTexts = [...texts].sort((a, b) => (a.text?.length ?? 0) - (b.text?.length ?? 0));
-
-      // Tokenize all texts concurrently upfront
-      const tokenStart = Date.now();
-      const tokenizedBatch = await Promise.all(
-        sortedTexts.map(async (item: any) => {
-          if (!item.text || typeof item.text !== "string") return { ...item, tokens: null };
-          try {
-            const tokens = await tokenizer!.segment(item.text);
-            return { ...item, tokens };
-          } catch (e) {
-            console.error(`[API] Tokenization error for item ${item.id}:`, e instanceof Error ? e.message : String(e));
-            return { ...item, tokens: null };
-          }
-        })
-      );
-      const tokenTime = Date.now() - tokenStart;
-      console.log(`[API] /api/batch-extract: Step 1 - Tokenization completed in ${tokenTime}ms`);
-
-      // Collect unique kana-only words from all texts
-      const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
-      const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
-      const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
-
-      const collectStart = Date.now();
-      const uniqueKanaWords = new Set<string>();
-      for (const item of tokenizedBatch) {
-        if (!item.tokens) continue;
-        for (const token of item.tokens) {
-          const surface = token.surface;
-          if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
-
-          const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
-          const isPureKatakana = /^[ァ-ヴー]+$/.test(surface);
-          if (isPureHiragana || isPureKatakana) {
-            uniqueKanaWords.add(surface);
-          }
-        }
-      }
-      const collectTime = Date.now() - collectStart;
-      console.log(`[API] /api/batch-extract: Step 2 - Found ${uniqueKanaWords.size} unique kana words in ${collectTime}ms`);
-
-      // Look up kana words via API with concurrency limit (KanjiData has wrong defs for pure kana)
-      const lookupStart = Date.now();
-      const kanaLookupCache = new Map<string, any>();
-      if (dictionary && uniqueKanaWords.size > 0) {
-        const words = Array.from(uniqueKanaWords);
-        const concurrencyLimit = 5;
-        const results: { word: string; result: any }[] = [];
-
-        let activeCount = 0;
-        let index = 0;
-
-        await new Promise<void>((resolve, reject) => {
-          const processNext = async () => {
-            try {
-              if (index >= words.length && activeCount === 0) {
-                resolve();
-                return;
-              }
-
-              if (activeCount < concurrencyLimit && index < words.length) {
-                const word = words[index++];
-                activeCount++;
-
-                try {
-                  const result = await dictionary!.lookup(word);
-                  results.push({ word, result });
-                } catch (e) {
-                  console.error(`[API] Kana lookup error for "${word}":`, e instanceof Error ? e.message : String(e));
-                  results.push({ word, result: null });
-                } finally {
-                  activeCount--;
-                  await processNext();
-                }
-              } else if (index < words.length) {
-                // Wait a bit before retrying
-                setTimeout(() => processNext().catch(reject), 10);
-              }
-            } catch (err) {
-              reject(err);
-            }
-          };
-
-          for (let i = 0; i < concurrencyLimit; i++) {
-            processNext().catch(reject);
-          }
-        });
-
-        for (const { word, result } of results) {
-          kanaLookupCache.set(word, result);
-          // Save kana lookups to persistent cache so they don't need API calls again
-          if (result) {
-            wordsCache.set(word, [{
-              meanings: [{ glosses: [result.meaning || 'Unknown'] }],
-              variants: [{ pronounced: result.reading || word, written: word }]
-            } as any]);
-          }
-        }
-      }
-      const lookupTime = Date.now() - lookupStart;
-      const foundCount = Array.from(kanaLookupCache.values()).filter(v => v !== null).length;
-      console.log(`[API] /api/batch-extract: Step 3 - Kana lookup completed in ${lookupTime}ms (${foundCount}/${uniqueKanaWords.size} found)`);
-
-      // Pre-populate wordsCache with kanji/mixed word lookups, deduplicated across all items
-      const kanjiPreloadStart = Date.now();
-      const uniqueKanjiWords = new Map<string, string>(); // surface -> baseForm
-      for (const item of tokenizedBatch) {
-        if (!item.tokens) continue;
-        for (const token of item.tokens) {
-          const surface = token.surface;
-          if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
-          const isPureHiragana = /^[ぁ-ん]+$/.test(surface);
-          const isPureKatakana = /^[ァ-ヴー]+$/.test(surface);
-          if (!isPureHiragana && !isPureKatakana && !uniqueKanjiWords.has(surface)) {
-            uniqueKanjiWords.set(surface, token.baseForm);
-          }
-        }
-      }
-      let kanjiPreloaded = 0;
-      for (const [surface, baseForm] of uniqueKanjiWords) {
-        if (!wordsCache.has(baseForm)) {
-          const entries = getCachedDictionaryEntries(baseForm);
-          if (entries.length > 0) {
-            wordsCache.set(baseForm, entries);
-            kanjiPreloaded++;
-          }
-        }
-        if (surface !== baseForm && !wordsCache.has(surface)) {
-          const entries = getCachedDictionaryEntries(surface);
-          if (entries.length > 0) {
-            wordsCache.set(surface, entries);
-          }
-        }
-      }
-      const kanjiPreloadTime = Date.now() - kanjiPreloadStart;
-      console.log(`[API] /api/batch-extract: Step 3.5 - Pre-loaded ${kanjiPreloaded}/${uniqueKanjiWords.size} kanji words in ${kanjiPreloadTime}ms`);
-
-      // Process texts with pre-looked-up kana cache
-      const processStart = Date.now();
-      const results = await Promise.all(
-        tokenizedBatch.map(async (item: any) => {
-          const { id, text, tokens } = item;
-          if (!text || typeof text !== "string") return { id, error: "No text" };
-          if (!tokens) return { id, error: "Tokenization failed" };
-
-          const start = Date.now();
-          try {
-            // Re-inject tokens to avoid re-tokenizing
-            const words = await processTextWithTokens(text, tokens, kanaLookupCache);
-            const elapsed = Date.now() - start;
-            console.log(`[API] batch-extract[${id}]: ${words.length} words in ${elapsed}ms`);
-            return { id, words, elapsed };
-          } catch (e: any) {
-            console.error(`[API] batch-extract[${id}]: Error:`, e instanceof Error ? e.message : String(e));
-            return { id, error: e instanceof Error ? e.message : String(e) };
-          }
-        })
-      );
-      const processTime = Date.now() - processStart;
-      const totalTime = Date.now() - batchStart;
-
-      console.log(`[API] /api/batch-extract: Step 4 - Text processing completed in ${processTime}ms`);
-
-      // Persist content-word associations to database
-      for (const result of results) {
-        if (result.words && Array.isArray(result.words)) {
-          contentWordsStore.setContentWords(result.id, result.words);
-        }
-      }
-      saveDatabase();
-
-      console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words (total: ${totalTime}ms)`);
+      const results = await runBatchExtract(texts);
       res.json(results);
     } catch (err: any) {
-      const elapsed = Date.now() - batchStart;
-      console.error(`[API] batch-extract failed after ${elapsed}ms:`, err instanceof Error ? err.message : String(err));
+      console.error(`[API] batch-extract failed:`, err instanceof Error ? err.message : String(err));
       res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
@@ -1128,6 +1096,31 @@ async function startServer() {
   const server = app.listen(PORT, "0.0.0.0", () => {
     console.log(`Server running on http://localhost:${PORT}`);
   });
+
+  // Kick off background extraction for any content not yet in content_words
+  (async () => {
+    try {
+      const allContent = [
+        ...loadStoriesFromDisk(),
+        ...loadMusicFromDisk(),
+        ...loadVideosFromDisk(),
+      ];
+      const missing = allContent.filter(c => !contentWordsStore.hasContent(c.id));
+      if (missing.length === 0) {
+        console.log('[Server] All content already extracted — skipping startup extraction');
+        return;
+      }
+      console.log(`[Server] Starting background extraction for ${missing.length}/${allContent.length} content items`);
+      const CHUNK_SIZE = 20;
+      for (let i = 0; i < missing.length; i += CHUNK_SIZE) {
+        const chunk = missing.slice(i, i + CHUNK_SIZE).map(c => ({ id: c.id, text: c.text }));
+        await runBatchExtract(chunk);
+      }
+      console.log(`[Server] Startup extraction complete`);
+    } catch (e) {
+      console.error('[Server] Startup extraction error:', e instanceof Error ? e.message : String(e));
+    }
+  })();
 
   // Keep server alive even if parent process tries to shut down
   let shutdownRequested = false;

--- a/server.ts
+++ b/server.ts
@@ -24,13 +24,14 @@ import { createTokenizer, Tokenizer } from "./src/lib/tokenizers.js";
 import { ensureJmnedictPrepared } from "./src/lib/jmnedict-utils.js";
 import { getMorphemeDefinition } from "./src/lib/morphemeDefinitions.js";
 import { loadStoriesFromDisk, loadMusicFromDisk, loadVideosFromDisk } from "./src/lib/storyLoader.js";
-import { initDatabase, WordsCache, JishoCache, saveDatabase } from "./src/lib/database.js";
+import { initDatabase, WordsCache, JishoCache, ContentWordsStore, saveDatabase } from "./src/lib/database.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 let wordsCache: WordsCache;
 let jishoCache: JishoCache;
+let contentWordsStore: ContentWordsStore;
 
 // Extract jmdict if needed
 async function ensureJmdictExtracted() {
@@ -109,6 +110,7 @@ const dictionaryReady = (async () => {
   await initDatabase();
   wordsCache = new WordsCache();
   jishoCache = new JishoCache();
+  contentWordsStore = new ContentWordsStore();
 
   dictionary = new DictionaryManager();
   const jmdictPath = path.join(__dirname, 'jmdict-db');
@@ -843,6 +845,15 @@ async function startServer() {
       const totalTime = Date.now() - batchStart;
 
       console.log(`[API] /api/batch-extract: Step 4 - Text processing completed in ${processTime}ms`);
+
+      // Persist content-word associations to database
+      for (const result of results) {
+        if (result.words && Array.isArray(result.words)) {
+          contentWordsStore.setContentWords(result.id, result.words);
+        }
+      }
+      saveDatabase();
+
       console.log(`[API] /api/batch-extract: Complete - cache now has ${wordsCache.size} words (total: ${totalTime}ms)`);
       res.json(results);
     } catch (err: any) {
@@ -922,6 +933,7 @@ async function startServer() {
 
     wordsCache.clear();
     jishoCache.clear();
+    contentWordsStore.clear();
     saveDatabase();
 
     console.log(`[API] /api/clear-cache: Cleared ${wordCacheSize} words and ${jishoCacheSize} Jisho entries`);
@@ -930,6 +942,25 @@ async function startServer() {
       cleared: true,
       message: `Cleared ${wordCacheSize} words and ${jishoCacheSize} Jisho entries`
     });
+  });
+
+  app.get("/api/content/words", (req, res) => {
+    try {
+      res.json(contentWordsStore.getAllContentWords());
+    } catch (e: any) {
+      console.error('[API Error] /api/content/words failed:', e.message);
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  app.get("/api/content/:contentId/words", (req, res) => {
+    try {
+      const { contentId } = req.params;
+      res.json(contentWordsStore.getContentWords(contentId));
+    } catch (e: any) {
+      console.error(`[API Error] /api/content/${req.params.contentId}/words failed:`, e.message);
+      res.status(500).json({ error: e.message });
+    }
   });
 
   app.post("/api/wanikani/validate", async (req, res) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { getAllContentWords } from './lib/api';
 import { BookOpen, Video, Music, CheckCircle, ChevronRight, PlayCircle, Loader2, Library, Plus, Settings, Search, X } from 'lucide-react';
 import { Content } from './data/content';
 import { useContentData, applyWaniKaniToWords } from './hooks/useContentData';
@@ -111,28 +112,51 @@ export default function App() {
   // Track whether we've attempted batch extraction
   const [batchExtractionAttempted, setBatchExtractionAttempted] = useState(false);
 
-  // Background batch processing of all stories to build cache
-  // Re-runs if cache is cleared (when contentVocab becomes empty)
+  // Background startup: load known vocab from server, then batch-extract only what's missing
   useEffect(() => {
-    const batchExtract = async () => {
-      // Helper function to fetch with retry logic
+    const startup = async () => {
+      if (!ALL_CONTENT.length) return;
+
+      // Step 1: Load all already-processed content words from server
+      let serverVocab: Record<string, WordInfo[]> = {};
+      try {
+        serverVocab = await getAllContentWords();
+        const count = Object.keys(serverVocab).length;
+        if (count > 0) {
+          console.log(`[App] Loaded vocab for ${count} content items from server`);
+          // Apply WaniKani multipliers if available
+          if (wkData) {
+            for (const id of Object.keys(serverVocab)) {
+              serverVocab[id] = applyWaniKaniToWords(serverVocab[id], wkData);
+            }
+          }
+          setContentVocab(prev => ({ ...prev, ...serverVocab }));
+        }
+      } catch (e) {
+        console.warn('[App] Could not load server vocab, will extract fresh:', e);
+      }
+
+      // Step 2: Identify content that has no server-side data yet
+      const missing = ALL_CONTENT.filter(c => !serverVocab[c.id]);
+      if (missing.length === 0) {
+        console.log('[App] All content already processed — skipping batch-extract');
+        setBatchExtractionAttempted(true);
+        return;
+      }
+
+      console.log(`[App] ${missing.length} content items need extraction`);
+
       const fetchWithRetry = async (url: string, options: RequestInit, maxRetries = 3) => {
         let lastError: any;
         for (let attempt = 0; attempt < maxRetries; attempt++) {
           try {
             const res = await fetch(url, options);
             if (res.ok) return res;
-
-            // Only retry on 504 Gateway Timeout, not other errors
-            if (res.status !== 504) {
-              return res;
-            }
+            if (res.status !== 504) return res;
             lastError = new Error(`504 Gateway Timeout`);
           } catch (e) {
             lastError = e;
           }
-
-          // Exponential backoff: 1s, 2s, 4s
           if (attempt < maxRetries - 1) {
             const delayMs = Math.pow(2, attempt) * 1000;
             console.log(`[App] Request failed, retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries - 1})`);
@@ -142,81 +166,59 @@ export default function App() {
         throw lastError || new Error(`Failed after ${maxRetries} attempts`);
       };
 
-      try {
-        const texts = ALL_CONTENT.map(c => ({ id: c.id, text: c.text }));
-        console.log(`[App] Starting background vocabulary extraction for ${texts.length} stories`);
+      // Step 3: Batch-extract only the missing content
+      const texts = missing.map(c => ({ id: c.id, text: c.text }));
+      const CHUNK_SIZE = 20;
+      let totalProcessed = 0;
 
-        const CHUNK_SIZE = 20;
-        const newVocab: Record<string, any[]> = {};
-        let totalProcessed = 0;
+      for (let i = 0; i < texts.length; i += CHUNK_SIZE) {
+        const chunk = texts.slice(i, i + CHUNK_SIZE);
+        const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
+        const totalChunks = Math.ceil(texts.length / CHUNK_SIZE);
+        console.log(`[App] Extracting chunk ${chunkNum}/${totalChunks}`);
 
-        // Process in chunks to avoid payload size limits
-        // Add delay between chunks to avoid overwhelming server
-        for (let i = 0; i < texts.length; i += CHUNK_SIZE) {
-          const chunk = texts.slice(i, i + CHUNK_SIZE);
-          const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
-          const totalChunks = Math.ceil(texts.length / CHUNK_SIZE);
-          console.log(`[App] Processing chunk ${chunkNum}/${totalChunks}`);
+        try {
+          const res = await fetchWithRetry("/api/batch-extract", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ texts: chunk })
+          });
 
-          try {
-            const res = await fetchWithRetry("/api/batch-extract", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ texts: chunk })
-            });
-
-            if (!res.ok) {
-              console.warn(`[App] Batch extract chunk ${chunkNum} failed with status ${res.status}`);
-              continue;
-            }
-
-            const results = await res.json();
-
-            // Accumulate results
-            for (const result of results) {
-              if (result.words && Array.isArray(result.words)) {
-                let words = result.words;
-                if (wkData) {
-                  words = applyWaniKaniToWords(words, wkData);
-                }
-                newVocab[result.id] = words;
-                totalProcessed++;
-              }
-            }
-
-            // Update UI incrementally as chunks complete
-            if (Object.keys(newVocab).length > 0) {
-              setContentVocab(prev => {
-                const updated = { ...prev, ...newVocab };
-                return updated;
-              });
-            }
-          } catch (chunkError) {
-            console.error(`[App] Failed to process chunk ${chunkNum}:`, chunkError);
+          if (!res.ok) {
+            console.warn(`[App] Batch extract chunk ${chunkNum} failed with status ${res.status}`);
+            continue;
           }
 
-          // Add delay between chunks (except after the last one) to avoid server overload
-          // Each chunk takes ~2+ minutes to process, so use longer delays
-          if (i + CHUNK_SIZE < texts.length) {
-            await new Promise(resolve => setTimeout(resolve, 5000));
+          const results = await res.json();
+          const newVocab: Record<string, WordInfo[]> = {};
+          for (const result of results) {
+            if (result.words && Array.isArray(result.words)) {
+              let words: WordInfo[] = result.words;
+              if (wkData) words = applyWaniKaniToWords(words, wkData);
+              newVocab[result.id] = words;
+              totalProcessed++;
+            }
           }
+
+          if (Object.keys(newVocab).length > 0) {
+            setContentVocab(prev => ({ ...prev, ...newVocab }));
+          }
+        } catch (chunkError) {
+          console.error(`[App] Failed to process chunk ${chunkNum}:`, chunkError);
         }
 
-        console.log(`[App] Background extraction complete: ${totalProcessed}/${texts.length} stories processed`);
-        setBatchExtractionAttempted(true);
-      } catch (e) {
-        console.error(`[App] Background extraction error:`, e);
-        setBatchExtractionAttempted(true);
+        if (i + CHUNK_SIZE < texts.length) {
+          await new Promise(resolve => setTimeout(resolve, 5000));
+        }
       }
+
+      console.log(`[App] Background extraction complete: ${totalProcessed}/${missing.length} new items processed`);
+      setBatchExtractionAttempted(true);
     };
 
-    // Run batch extract if:
-    // 1. Never attempted yet AND we have content to extract
-    const shouldRunExtraction =
-      !batchExtractionAttempted && ALL_CONTENT.length > 0;
-
-    if (shouldRunExtraction) {
-      const timer = setTimeout(batchExtract, 500);
+    const shouldRun = !batchExtractionAttempted && ALL_CONTENT.length > 0;
+    if (shouldRun) {
+      const timer = setTimeout(startup, 500);
       return () => clearTimeout(timer);
     }
   }, [ALL_CONTENT.length, batchExtractionAttempted, wkData]);

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { WordInfo } from '../types';
-import { extractVocabulary } from '../lib/api';
+import { extractVocabulary, getContentWords } from '../lib/api';
 import { Content } from '../data/content';
 import { WaniKaniData, getWaniKaniMultiplier, getWaniKaniSrsStage, loadCachedWaniKaniData } from '../lib/wanikani';
 
@@ -135,10 +135,25 @@ export function useContentData() {
     setLoadingContent(prev => ({ ...prev, [content.id]: true }));
     console.log(`[Vocab] Loading vocabulary for "${content.id}"`);
     try {
-      let words = await extractVocabulary(content.text, (status) => {
-        console.log(`[Vocab] ${status}`);
-      });
-      console.log(`[Vocab] Loaded ${words.length} words for "${content.id}"`);
+      // Try server-side store first — avoids re-extraction if already processed
+      let words: WordInfo[] = [];
+      if (!forceReload) {
+        try {
+          words = await getContentWords(content.id);
+          if (words.length > 0) {
+            console.log(`[Vocab] Loaded ${words.length} words for "${content.id}" from server`);
+          }
+        } catch (e) {
+          console.warn(`[Vocab] Server fetch failed for "${content.id}", falling back to extraction`);
+        }
+      }
+
+      if (words.length === 0) {
+        words = await extractVocabulary(content.text, (status) => {
+          console.log(`[Vocab] ${status}`);
+        });
+        console.log(`[Vocab] Extracted ${words.length} words for "${content.id}"`);
+      }
 
       if (wkDataRef.current) {
         words = applyWaniKaniToWords(words, wkDataRef.current);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,17 @@
 import { WordInfo } from "../types";
 
+export async function getAllContentWords(): Promise<Record<string, WordInfo[]>> {
+  const res = await fetch("/api/content/words");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function getContentWords(contentId: string): Promise<WordInfo[]> {
+  const res = await fetch(`/api/content/${encodeURIComponent(contentId)}/words`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
 export async function clearServerCache(): Promise<void> {
   const res = await fetch("/api/clear-cache", {
     method: "POST",

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -10,6 +10,7 @@ const DB_PATH = path.join(__dirname, '../../.cache.db');
 
 let db: SqlDatabase | null = null;
 let SQL: any = null;
+let isDirty = false;
 
 export async function initDatabase() {
   SQL = await initSqlJs();
@@ -65,11 +66,11 @@ function createTables() {
 }
 
 export function saveDatabase() {
-  if (!db) return;
-
+  if (!db || !isDirty) return;
   const data = db.export();
   const buffer = Buffer.from(data);
   fs.writeFileSync(DB_PATH, buffer);
+  isDirty = false;
   console.log('[Database] Saved to disk');
 }
 
@@ -84,6 +85,7 @@ export class WordsCache {
       [key, JSON.stringify(value)]
     );
     this.memoryCache.set(key, value);
+    isDirty = true;
   }
 
   get(key: string): DictionaryEntry[] | undefined {
@@ -125,6 +127,7 @@ export class WordsCache {
     if (!db) throw new Error('Database not initialized');
     db.run('DELETE FROM words_cache');
     this.memoryCache.clear();
+    isDirty = true;
   }
 
   entries(): [string, DictionaryEntry[]][] {
@@ -168,6 +171,7 @@ export class JishoCache {
       'INSERT OR REPLACE INTO jisho_cache (word, result) VALUES (?, ?)',
       [key, JSON.stringify(value)]
     );
+    isDirty = true;
   }
 
   get(key: string): any | undefined {
@@ -194,6 +198,7 @@ export class JishoCache {
   clear() {
     if (!db) throw new Error('Database not initialized');
     db.run('DELETE FROM jisho_cache');
+    isDirty = true;
   }
 
   entries(): [string, any][] {
@@ -218,6 +223,7 @@ export class ContentWordsStore {
   setContentWords(contentId: string, words: WordInfo[]): void {
     if (!db) throw new Error('Database not initialized');
     db.run('DELETE FROM content_words WHERE content_id = ?', [contentId]);
+    isDirty = true;
     for (const w of words) {
       db.run(
         `INSERT INTO content_words
@@ -302,10 +308,12 @@ export class ContentWordsStore {
   deleteContentWords(contentId: string): void {
     if (!db) throw new Error('Database not initialized');
     db.run('DELETE FROM content_words WHERE content_id = ?', [contentId]);
+    isDirty = true;
   }
 
   clear(): void {
     if (!db) throw new Error('Database not initialized');
     db.run('DELETE FROM content_words');
+    isDirty = true;
   }
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { DictionaryEntry } from './scoring.js';
+import { WordInfo } from '../types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = path.join(__dirname, '../../.cache.db');
@@ -20,15 +21,15 @@ export async function initDatabase() {
     console.log('[Database] Loaded existing database');
   } else {
     db = new SQL.Database();
-    createTables();
     console.log('[Database] Created new database');
   }
+  // Always run createTables — IF NOT EXISTS makes this safe for existing DBs
+  createTables();
 }
 
 function createTables() {
   if (!db) throw new Error('Database not initialized');
 
-  // Words cache table
   db.run(`
     CREATE TABLE IF NOT EXISTS words_cache (
       word TEXT PRIMARY KEY,
@@ -36,11 +37,27 @@ function createTables() {
     )
   `);
 
-  // Jisho cache table
   db.run(`
     CREATE TABLE IF NOT EXISTS jisho_cache (
       word TEXT PRIMARY KEY,
       result TEXT NOT NULL
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS content_words (
+      content_id TEXT NOT NULL,
+      word TEXT NOT NULL,
+      reading TEXT NOT NULL,
+      meaning TEXT NOT NULL,
+      meanings TEXT,
+      jlpt INTEGER NOT NULL DEFAULT 0,
+      joyo INTEGER NOT NULL DEFAULT 0,
+      score REAL NOT NULL DEFAULT 0,
+      breakdown TEXT NOT NULL,
+      frequency INTEGER NOT NULL DEFAULT 1,
+      is_morpheme INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (content_id, word)
     )
   `);
 
@@ -194,5 +211,101 @@ export class JishoCache {
     const result = db.exec('SELECT COUNT(*) as count FROM jisho_cache');
     if (result.length === 0) return 0;
     return result[0].values[0][0] as number;
+  }
+}
+
+export class ContentWordsStore {
+  setContentWords(contentId: string, words: WordInfo[]): void {
+    if (!db) throw new Error('Database not initialized');
+    db.run('DELETE FROM content_words WHERE content_id = ?', [contentId]);
+    for (const w of words) {
+      db.run(
+        `INSERT INTO content_words
+           (content_id, word, reading, meaning, meanings, jlpt, joyo, score, breakdown, frequency, is_morpheme)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          contentId,
+          w.word,
+          w.reading,
+          w.meaning,
+          w.meanings ? JSON.stringify(w.meanings) : null,
+          w.jlpt,
+          w.joyo ? 1 : 0,
+          w.score,
+          JSON.stringify(w.breakdown ?? {}),
+          w.frequencyInContent ?? 1,
+          w.isMorpheme ? 1 : 0,
+        ]
+      );
+    }
+  }
+
+  getContentWords(contentId: string): WordInfo[] {
+    if (!db) throw new Error('Database not initialized');
+    const result = db.exec(
+      `SELECT word, reading, meaning, meanings, jlpt, joyo, score, breakdown, frequency, is_morpheme
+       FROM content_words WHERE content_id = ?
+       ORDER BY rowid`,
+      [contentId]
+    );
+    if (result.length === 0) return [];
+    return result[0].values.map(([word, reading, meaning, meanings, jlpt, joyo, score, breakdown, frequency, is_morpheme]) => ({
+      word: word as string,
+      reading: reading as string,
+      meaning: meaning as string,
+      ...(meanings ? { meanings: JSON.parse(meanings as string) } : {}),
+      jlpt: jlpt as number,
+      joyo: (joyo as number) === 1,
+      score: score as number,
+      breakdown: JSON.parse(breakdown as string),
+      frequencyInContent: frequency as number,
+      ...(is_morpheme ? { isMorpheme: true } : {}),
+    }));
+  }
+
+  getAllContentWords(): Record<string, WordInfo[]> {
+    if (!db) throw new Error('Database not initialized');
+    const result = db.exec(
+      `SELECT content_id, word, reading, meaning, meanings, jlpt, joyo, score, breakdown, frequency, is_morpheme
+       FROM content_words ORDER BY content_id, rowid`
+    );
+    if (result.length === 0) return {};
+    const out: Record<string, WordInfo[]> = {};
+    for (const [content_id, word, reading, meaning, meanings, jlpt, joyo, score, breakdown, frequency, is_morpheme] of result[0].values) {
+      const id = content_id as string;
+      if (!out[id]) out[id] = [];
+      out[id].push({
+        word: word as string,
+        reading: reading as string,
+        meaning: meaning as string,
+        ...(meanings ? { meanings: JSON.parse(meanings as string) } : {}),
+        jlpt: jlpt as number,
+        joyo: (joyo as number) === 1,
+        score: score as number,
+        breakdown: JSON.parse(breakdown as string),
+        frequencyInContent: frequency as number,
+        ...(is_morpheme ? { isMorpheme: true } : {}),
+      });
+    }
+    return out;
+  }
+
+  hasContent(contentId: string): boolean {
+    if (!db) throw new Error('Database not initialized');
+    const result = db.exec(
+      'SELECT 1 FROM content_words WHERE content_id = ? LIMIT 1',
+      [contentId]
+    );
+    return result.length > 0 && result[0].values.length > 0;
+  }
+
+  deleteContentWords(contentId: string): void {
+    if (!db) throw new Error('Database not initialized');
+    db.run('DELETE FROM content_words WHERE content_id = ?', [contentId]);
+  }
+
+  clear(): void {
+    if (!db) throw new Error('Database not initialized');
+    db.run('DELETE FROM content_words');
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces persistent storage of extracted vocabulary for each content item and optimizes the batch extraction pipeline to avoid re-processing already-extracted content. The changes include a new database table for content-word associations, server-side startup extraction for missing content, and client-side logic to load pre-processed vocabulary from the server.

## Key Changes

- **New `ContentWordsStore` class** (`src/lib/database.ts`): Manages persistent storage of word-content associations in a new `content_words` database table, with methods to store, retrieve, and query vocabulary by content ID.

- **Refactored batch extraction** (`server.ts`): Extracted the `/api/batch-extract` handler logic into a reusable `runBatchExtract()` function that can be called both from API endpoints and server startup routines.

- **Server-side startup extraction** (`server.ts`): Added background extraction on server startup that processes any content items not yet in the `content_words` store, chunked to avoid overwhelming the server.

- **New API endpoints** (`server.ts`):
  - `GET /api/content/words`: Returns all stored content-word associations
  - `GET /api/content/:contentId/words`: Returns vocabulary for a specific content item

- **Optimized client startup** (`src/App.tsx`): Changed the batch extraction flow to first load pre-processed vocabulary from the server, then only extract vocabulary for missing content items. This avoids redundant processing when the app reloads.

- **Per-content vocabulary loading** (`src/hooks/useContentData.ts`): Updated `useContentData` hook to check the server store before falling back to on-demand extraction, reducing client-side processing.

- **Database dirty-flag optimization** (`src/lib/database.ts`): Added `isDirty` flag to only persist database changes when modifications occur, and removed the periodic 30-second save interval in favor of explicit saves after batch operations.

## Implementation Details

- The `ContentWordsStore` persists all `WordInfo` fields including meanings, JLPT level, Jōyō status, frequency, and morpheme flags.
- Batch extraction now pre-collects unique kana and kanji words across all texts before lookup, reducing redundant dictionary queries.
- Server startup extraction runs in chunks of 20 items to balance throughput with resource usage.
- Client-side extraction respects WaniKani data multipliers when loading from both server and local extraction.

https://claude.ai/code/session_01F7faJnmVyLYbudRqzXWJD3