### PR TITLE
Fix dictionary lookup: language filtering, sense ordering, and kana-only words

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -189,9 +189,9 @@ const dictionaryReady = (async () => {
 async function resolveWordMeaning(
   wordStr: string,
   baseForm: string,
-  kanaCache?: Map<string, any>
+  lookupCache?: Map<string, any>
 ): Promise<{ reading: string; meaning: string; meanings: string[] | undefined }> {
-  // Step 1: kanji-data (fast, synchronous, covers kanji words)
+  // Step 1: kanji-data (fast, synchronous) — used for reading and as fallback meaning
   let entries = getCachedDictionaryEntries(baseForm);
   if (entries.length === 0 && baseForm !== wordStr) {
     entries = getCachedDictionaryEntries(wordStr);
@@ -199,63 +199,63 @@ async function resolveWordMeaning(
   const { variant, entry } = findBestVariant(baseForm, entries);
 
   let reading  = wordStr;
-  let meaning  = "Unknown meaning";
-  let meanings: string[] | undefined = undefined;
+  let kanjiMeaning  = "Unknown meaning";
+  let kanjiMeanings: string[] | undefined = undefined;
 
   if (entry && variant) {
     reading = variant.pronounced || wordStr;
-    meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
-    // Collect all meanings in insertion order — no Set, which loses ordering
-    const allMeanings: string[] = [];
+    kanjiMeaning = entry.meanings[0]?.glosses?.join(", ") || kanjiMeaning;
+    const allKanjiMeanings: string[] = [];
     const seen = new Set<string>();
     for (const m of entry.meanings) {
       for (const g of (m.glosses || [])) {
-        if (!seen.has(g)) { seen.add(g); allMeanings.push(g); }
+        if (!seen.has(g)) { seen.add(g); allKanjiMeanings.push(g); }
       }
     }
-    if (allMeanings.length > 1) meanings = allMeanings;
+    if (allKanjiMeanings.length > 1) kanjiMeanings = allKanjiMeanings;
   }
 
-  // Step 2: for kana-only words (です, ます, katakana loanwords, etc.) kanji-data
-  // has no data. Fall through to JMDict / Jisho when the dictionary is available.
-  const isKanaOnly = /^[ぁ-ん]+$/.test(wordStr) || /^[ァ-ヴー]+$/.test(wordStr);
-  if (isKanaOnly && dictionary) {
-    const cachedEntries = wordsCache.get(wordStr);
-    let dictResult: any = null;
+  // Step 2: JMDict lookup for ALL words (not just kana-only).
+  //
+  // kanji-data sense ordering is not controlled by us — it can put rare, archaic,
+  // or slang senses first (e.g. 猫→"submissive partner", 春→"New Year").
+  // JMDict results are sorted by getSenseCommonness() which deprioritises those
+  // senses. We prefer JMDict when it returns something; kanji-data is the fallback.
+  let meaning  = kanjiMeaning;
+  let meanings = kanjiMeanings;
 
-    if (cachedEntries && cachedEntries.length > 0 && cachedEntries[0].meanings?.length > 0) {
-      const ce = cachedEntries[0];
-      dictResult = {
-        meaning:  ce.meanings[0]?.glosses?.join(", ") || "Unknown",
-        reading:  ce.variants?.[0]?.pronounced || wordStr,
-        meanings: ce.meanings.map((m: any) => m.glosses?.join(", ")).filter(Boolean),
-      };
-    } else {
-      dictResult = kanaCache?.get(wordStr);
-      if (!dictResult) {
+  if (dictionary) {
+    // Use the same cache for both kana-only words (original behaviour) and kanji words.
+    const cacheKey = baseForm !== wordStr ? baseForm : wordStr;
+    let dictResult: any = lookupCache?.get(cacheKey) ?? null;
+
+    if (dictResult === null) {
+      // Try baseForm first (dictionary/citation form of conjugated verbs), then surface
+      dictResult = await dictionary.lookup(baseForm);
+      if (!dictResult && baseForm !== wordStr) {
         dictResult = await dictionary.lookup(wordStr);
-        kanaCache?.set(wordStr, dictResult ?? null);
       }
-      if (dictResult) {
-        const cacheEntry: DictionaryEntry = {
-          meanings: (dictResult.meanings || [dictResult.meaning])
-            .filter(Boolean)
-            .map((m: string) => ({ glosses: [m] })),
-          variants: [{ pronounced: dictResult.reading || wordStr, written: wordStr, priorities: [] }],
-        };
-        wordsCache.set(wordStr, [cacheEntry]);
-      }
+      lookupCache?.set(cacheKey, dictResult ?? false); // false = "looked up, not found"
     }
 
-    if (dictResult) {
-      meaning  = dictResult.meaning;
-      meanings = dictResult.meanings;
-      reading  = dictResult.reading || wordStr;
+    if (dictResult && dictResult !== false) {
+      const jmdictMeaning = dictResult.meaning;
+      // Only use JMDict result when it actually has an English definition.
+      // readingAnywhere/kanjiAnywhere can match compound entries that share a
+      // character but have no English glosses — those come back as "Unknown".
+      if (jmdictMeaning && jmdictMeaning !== 'Unknown') {
+        // Keep kanji-data reading (it matched the conjugated surface form exactly);
+        // only use JMDict reading for kana-only words where kanji-data had nothing.
+        if (!reading || reading === wordStr) reading = dictResult.reading || reading;
+        meaning  = jmdictMeaning;
+        meanings = dictResult.meanings;
+      }
     }
   }
 
   if (meaning === "Unknown meaning" && /^[ぁ-ん]+$/.test(wordStr)) {
-    meaning = "Kana particle / expression";
+    const morphemeFallback = getMorphemeDefinition(wordStr);
+    meaning = morphemeFallback || "Kana particle / expression";
   }
 
   return { reading, meaning, meanings };
@@ -278,9 +278,9 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
     const surface = token.surface;
     if (surface.trim() === '' || isPunctuation(surface)) continue;
 
-    if (isSingleKana(surface)) {
-      // Check if it's a morpheme we have a definition for
-      const morphemeDef = getMorphemeDefinition(surface);
+    const morphemeDef = getMorphemeDefinition(surface);
+    const isKanaMorpheme = morphemeDef && /^[ぁ-んー]+$/.test(surface);
+    if (isSingleKana(surface) || isKanaMorpheme) {
       if (morphemeDef) {
         morphemes.set(surface, (morphemes.get(surface) ?? 0) + 1);
       }
@@ -371,9 +371,9 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
     const surface = token.surface;
     if (surface.trim() === '' || isPunctuation(surface)) continue;
 
-    if (isSingleKana(surface)) {
-      // Check if it's a morpheme we have a definition for
-      const morphemeDef = getMorphemeDefinition(surface);
+    const morphemeDef = getMorphemeDefinition(surface);
+    const isKanaMorpheme = morphemeDef && /^[ぁ-んー]+$/.test(surface);
+    if (isSingleKana(surface) || isKanaMorpheme) {
       if (morphemeDef) {
         morphemes.set(surface, (morphemes.get(surface) ?? 0) + 1);
       }

--- a/server.ts
+++ b/server.ts
@@ -174,6 +174,93 @@ const dictionaryReady = (async () => {
 })();
 
 
+/**
+ * Single source of truth for resolving a Japanese word's reading + meaning.
+ *
+ * Fix for #188: three separate code paths (processText, processStoryText, and
+ * /api/word/:word) previously had slightly different lookup logic. The word
+ * detail page only used getCachedDictionaryEntries (kanji-data) and never called
+ * the dictionary for kana-only words like です/ます, so the word detail page
+ * returned "Unknown meaning" while the vocab card showed the correct definition.
+ *
+ * All paths now call this function so reading/meaning/meanings are always derived
+ * the same way regardless of which view renders the word.
+ */
+async function resolveWordMeaning(
+  wordStr: string,
+  baseForm: string,
+  kanaCache?: Map<string, any>
+): Promise<{ reading: string; meaning: string; meanings: string[] | undefined }> {
+  // Step 1: kanji-data (fast, synchronous, covers kanji words)
+  let entries = getCachedDictionaryEntries(baseForm);
+  if (entries.length === 0 && baseForm !== wordStr) {
+    entries = getCachedDictionaryEntries(wordStr);
+  }
+  const { variant, entry } = findBestVariant(baseForm, entries);
+
+  let reading  = wordStr;
+  let meaning  = "Unknown meaning";
+  let meanings: string[] | undefined = undefined;
+
+  if (entry && variant) {
+    reading = variant.pronounced || wordStr;
+    meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
+    // Collect all meanings in insertion order — no Set, which loses ordering
+    const allMeanings: string[] = [];
+    const seen = new Set<string>();
+    for (const m of entry.meanings) {
+      for (const g of (m.glosses || [])) {
+        if (!seen.has(g)) { seen.add(g); allMeanings.push(g); }
+      }
+    }
+    if (allMeanings.length > 1) meanings = allMeanings;
+  }
+
+  // Step 2: for kana-only words (です, ます, katakana loanwords, etc.) kanji-data
+  // has no data. Fall through to JMDict / Jisho when the dictionary is available.
+  const isKanaOnly = /^[ぁ-ん]+$/.test(wordStr) || /^[ァ-ヴー]+$/.test(wordStr);
+  if (isKanaOnly && dictionary) {
+    const cachedEntries = wordsCache.get(wordStr);
+    let dictResult: any = null;
+
+    if (cachedEntries && cachedEntries.length > 0 && cachedEntries[0].meanings?.length > 0) {
+      const ce = cachedEntries[0];
+      dictResult = {
+        meaning:  ce.meanings[0]?.glosses?.join(", ") || "Unknown",
+        reading:  ce.variants?.[0]?.pronounced || wordStr,
+        meanings: ce.meanings.map((m: any) => m.glosses?.join(", ")).filter(Boolean),
+      };
+    } else {
+      dictResult = kanaCache?.get(wordStr);
+      if (!dictResult) {
+        dictResult = await dictionary.lookup(wordStr);
+        kanaCache?.set(wordStr, dictResult ?? null);
+      }
+      if (dictResult) {
+        const cacheEntry: DictionaryEntry = {
+          meanings: (dictResult.meanings || [dictResult.meaning])
+            .filter(Boolean)
+            .map((m: string) => ({ glosses: [m] })),
+          variants: [{ pronounced: dictResult.reading || wordStr, written: wordStr, priorities: [] }],
+        };
+        wordsCache.set(wordStr, [cacheEntry]);
+      }
+    }
+
+    if (dictResult) {
+      meaning  = dictResult.meaning;
+      meanings = dictResult.meanings;
+      reading  = dictResult.reading || wordStr;
+    }
+  }
+
+  if (meaning === "Unknown meaning" && /^[ぁ-ん]+$/.test(wordStr)) {
+    meaning = "Kana particle / expression";
+  }
+
+  return { reading, meaning, meanings };
+}
+
 async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
   const tokens = await tokenizer.segment(text);
@@ -236,84 +323,14 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
       console.log(`[API] Slow lookup: "${wordStr}" took ${lookupTime}ms`);
     }
 
-    const { variant, entry } = findBestVariant(baseForm, entries);
+    const { reading, meaning, meanings } = await resolveWordMeaning(wordStr, baseForm, kanaLookupCache);
 
-    let meaning = "Unknown meaning";
-    let meanings: string[] | undefined = undefined;
-    let reading = wordStr;
-
-    if (entry && variant) {
-      reading = variant.pronounced || wordStr;
-      meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
-    }
-
-    // Use dictionary (Jisho API or jmdict) for pure hiragana or katakana words
-    // These are particles, auxiliaries, and other kana-only words where kanji-data is unreliable
-    const isPureHiragana = /^[ぁ-ん]+$/.test(wordStr);
-    const isPureKatakana = /^[ァ-ヴー]+$/.test(wordStr);
-    const isKanaOnly = isPureHiragana || isPureKatakana;
-
-    if (isKanaOnly && dictionary) {
-      // Try persistent cache first, then batch cache, then dictionary lookup
-      const cachedEntries = wordsCache.get(wordStr);
-      let dictResult: any = null;
-
-      if (cachedEntries && cachedEntries.length > 0) {
-        // Use cached entry
-        const entry = cachedEntries[0];
-        if (entry.meanings && entry.meanings.length > 0) {
-          dictResult = {
-            meaning: entry.meanings[0]?.glosses?.join(", ") || "Unknown",
-            reading: entry.variants?.[0]?.pronounced || wordStr,
-            meanings: entry.meanings.map((m: any) => m.glosses?.join(", ")).filter((m: any) => m)
-          };
-        }
-      } else {
-        // Try batch cache first, then dictionary lookup
-        dictResult = kanaLookupCache?.get(wordStr);
-        if (!dictResult) {
-          dictResult = await dictionary.lookup(wordStr);
-          // Save to batch cache for reuse within this request
-          if (dictResult) {
-            kanaLookupCache?.set(wordStr, dictResult);
-          }
-        }
-
-        // Save dictionary result to persistent cache for future requests
-        if (dictResult) {
-          const entry: DictionaryEntry = {
-            meanings: (dictResult.meanings || [dictResult.meaning])
-              .filter(Boolean)
-              .map((m: string) => ({ glosses: [m] })),
-            variants: [{
-              pronounced: dictResult.reading || wordStr,
-              written: wordStr,
-              priorities: []
-            }]
-          };
-          wordsCache.set(wordStr, [entry]);
-        }
-      }
-
-      if (dictResult) {
-        meaning = dictResult.meaning;
-        if (dictResult.meanings) {
-          meanings = dictResult.meanings;
-        }
-      }
-    }
-
-    // Fallback for pure hiragana particles if still no result from dictionary
-    if (meaning === "Unknown meaning" && isPureHiragana) {
-      meaning = "Kana particle / expression";
-    }
-
+    // Still need variant for score calculation; resolveWordMeaning handles meaning lookup
+    const { variant } = findBestVariant(baseForm, entries);
     const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
     const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
     const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
-    if (meanings) {
-      wordData.meanings = meanings;
-    }
+    if (meanings) wordData.meanings = meanings;
     results.push(wordData);
   }
 
@@ -399,61 +416,13 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
       console.log(`[API] Slow lookup: "${wordStr}" took ${lookupTime}ms`);
     }
 
-    const { variant, entry } = findBestVariant(baseForm, entries);
+    const { reading, meaning, meanings } = await resolveWordMeaning(wordStr, baseForm, kanaLookupCache);
 
-    let meaning = "Unknown meaning";
-    let meanings: string[] | undefined = undefined;
-    let reading = wordStr;
-
-    if (entry && variant) {
-      reading = variant.pronounced || wordStr;
-      meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
-    }
-
-    // Use dictionary (Jisho API or jmdict) for pure hiragana or katakana words
-    const isPureHiragana = /^[ぁ-ん]+$/.test(wordStr);
-    const isPureKatakana = /^[ァ-ヴー]+$/.test(wordStr);
-    const isKanaOnly = isPureHiragana || isPureKatakana;
-
-    if (isKanaOnly) {
-      // Try persistent cache first, then batch cache
-      const cachedEntries = wordsCache.get(wordStr);
-      let dictResult: any = null;
-
-      if (cachedEntries && cachedEntries.length > 0) {
-        // Use cached entry
-        const entry = cachedEntries[0];
-        if (entry.meanings && entry.meanings.length > 0) {
-          dictResult = {
-            meaning: entry.meanings[0]?.glosses?.join(", ") || "Unknown",
-            reading: entry.variants?.[0]?.pronounced || wordStr,
-            meanings: entry.meanings.map((m: any) => m.glosses?.join(", ")).filter((m: any) => m)
-          };
-        }
-      } else {
-        // Fall back to batch cache
-        dictResult = kanaLookupCache.get(wordStr);
-      }
-
-      if (dictResult) {
-        meaning = dictResult.meaning;
-        if (dictResult.meanings) {
-          meanings = dictResult.meanings;
-        }
-      }
-    }
-
-    // Fallback for pure hiragana particles if still no result from dictionary
-    if (meaning === "Unknown meaning" && isPureHiragana) {
-      meaning = "Kana particle / expression";
-    }
-
+    const { variant } = findBestVariant(baseForm, entries);
     const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
     const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
     const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
-    if (meanings) {
-      wordData.meanings = meanings;
-    }
+    if (meanings) wordData.meanings = meanings;
     results.push(wordData);
   }
 
@@ -522,67 +491,16 @@ async function processStoryText(text: string) {
   for (const token of vocabTokens) {
     if (tokenMap.has(token.surface)) continue;
 
-    // Try baseForm first for dictionary lookup
+    const { reading, meaning, meanings } = await resolveWordMeaning(token.surface, token.baseForm);
+
     let entries = getCachedDictionaryEntries(token.baseForm);
     if (entries.length === 0 && token.baseForm !== token.surface) {
       entries = getCachedDictionaryEntries(token.surface);
     }
-    const { variant, entry } = findBestVariant(token.baseForm, entries);
-
-    let meaning = "Unknown meaning";
-    let meanings: string[] | undefined = undefined;
-    let reading = token.surface;
-
-    if (entry && variant) {
-      reading = variant.pronounced || token.surface;
-      meaning = entry.meanings[0]?.glosses?.join(", ") || meaning;
-    }
-
-    const isPureHiragana = /^[ぁ-ん]+$/.test(token.surface);
-    if (isPureHiragana && dictionary) {
-      // Try persistent cache first, then dictionary lookup
-      const cachedEntries = wordsCache.get(token.surface);
-      let dictResult: any = null;
-
-      if (cachedEntries && cachedEntries.length > 0) {
-        // Use cached entry
-        const entry = cachedEntries[0];
-        if (entry.meanings && entry.meanings.length > 0) {
-          dictResult = {
-            meaning: entry.meanings[0]?.glosses?.join(", ") || "Unknown",
-            reading: entry.variants?.[0]?.pronounced || token.surface,
-            meanings: entry.meanings.map((m: any) => m.glosses?.join(", ")).filter((m: any) => m)
-          };
-        }
-      } else {
-        // Fall back to dictionary lookup
-        dictResult = await dictionary.lookup(token.surface);
-      }
-
-      if (dictResult) {
-        meaning = dictResult.meaning;
-        if (dictResult.meanings) {
-          meanings = dictResult.meanings;
-        }
-      }
-    }
-
-    if (meaning === "Unknown meaning" && isPureHiragana) {
-      meaning = "Kana particle / expression";
-    }
-
+    const { variant } = findBestVariant(token.baseForm, entries);
     const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(token.surface, variant);
 
-    tokenMap.set(token.surface, {
-      word: token.surface,
-      reading,
-      meaning,
-      jlpt,
-      joyo,
-      score,
-      breakdown,
-      meanings,
-    });
+    tokenMap.set(token.surface, { word: token.surface, reading, meaning, jlpt, joyo, score, breakdown, meanings });
   }
 
   // Add morpheme definitions to tokenMap
@@ -955,46 +873,20 @@ async function startServer() {
         return res.status(400).json({ error: 'No word provided' });
       }
 
+      // Use resolveWordMeaning so this endpoint uses the same pipeline as the
+      // extract/batch-extract paths. Previously this handler only used kanji-data
+      // and never called the dictionary, so kana-only words (です, ます, etc.)
+      // returned "Unknown meaning" here even though the vocab card showed the
+      // correct definition. Also fixes the Set-based meanings collection that
+      // lost the original sense ordering (#188).
+      const { reading, meaning, meanings } = await resolveWordMeaning(word, word);
+
       const entries = getCachedDictionaryEntries(word);
       const { variant, entry } = findBestVariant(word, entries);
-
-      let reading = word;
-      let meaning = "Unknown meaning";
-      let meanings: string[] | undefined = undefined;
-
-      if (entry && variant) {
-        reading = variant.pronounced || word;
-        if (entry.meanings && entry.meanings.length > 0) {
-          meaning = entry.meanings[0].glosses?.join(", ") || meaning;
-          // Collect all unique meanings
-          const allMeanings = new Set<string>();
-          for (const m of entry.meanings) {
-            if (m.glosses) {
-              for (const gloss of m.glosses) {
-                allMeanings.add(gloss);
-              }
-            }
-          }
-          meanings = Array.from(allMeanings);
-        }
-      }
-
       const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(word, variant);
 
-      const wordData: any = {
-        word,
-        reading,
-        meaning,
-        jlpt,
-        joyo,
-        score,
-        breakdown,
-        entry
-      };
-
-      if (meanings) {
-        wordData.meanings = meanings;
-      }
+      const wordData: any = { word, reading, meaning, jlpt, joyo, score, breakdown, entry };
+      if (meanings) wordData.meanings = meanings;
 
       const elapsed = Date.now() - start;
       console.log(`[API] /api/word/${word}: completed in ${elapsed}ms`);

--- a/src/lib/dictionary.test.ts
+++ b/src/lib/dictionary.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { getEnglishGlosses, getSenseCommonness } from './dictionary';
+
+// ---------------------------------------------------------------------------
+// #186 – Language filtering: getEnglishGlosses
+//
+// Before the fix, JmdictDictionary.lookup() had:
+//
+//   if (glossTexts.length > 0) { meanings.push(...glossTexts); }
+//   else if (sense.gloss[0]?.text) { meanings.push(sense.gloss[0].text); }  // ← BUG
+//
+// The "else if" pushed sense.gloss[0].text without checking g.lang, so JMDict
+// senses that have German or Spanish glosses but no English ones would return a
+// non-English definition as the primary meaning.
+// ---------------------------------------------------------------------------
+
+describe('getEnglishGlosses – #186 language filtering', () => {
+  it('returns empty array when the sense has only non-English glosses', () => {
+    // Before fix: sense.gloss[0].text ('Katze') would be returned as a definition
+    const sense = {
+      gloss: [
+        { text: 'Katze', lang: 'ger' },
+        { text: 'gato', lang: 'spa' },
+      ],
+    };
+    expect(getEnglishGlosses(sense)).toEqual([]);
+  });
+
+  it('filters out non-English entries when glosses are mixed languages', () => {
+    const sense = {
+      gloss: [
+        { text: 'Katze', lang: 'ger' },
+        { text: 'cat', lang: 'en' },
+        { text: 'chat', lang: 'fre' },
+      ],
+    };
+    expect(getEnglishGlosses(sense)).toEqual(['cat']);
+  });
+
+  it('returns all English glosses when all entries are English', () => {
+    const sense = {
+      gloss: [
+        { text: 'cat', lang: 'en' },
+        { text: 'kitty', lang: 'en' },
+      ],
+    };
+    expect(getEnglishGlosses(sense)).toEqual(['cat', 'kitty']);
+  });
+
+  it('returns empty array for a sense with no glosses', () => {
+    expect(getEnglishGlosses({ gloss: [] })).toEqual([]);
+  });
+
+  it('returns empty array when sense has no gloss field at all', () => {
+    expect(getEnglishGlosses({})).toEqual([]);
+  });
+
+  it('preserves original order of English glosses', () => {
+    const sense = {
+      gloss: [
+        { text: 'cute', lang: 'en' },
+        { text: 'adorable', lang: 'en' },
+        { text: 'hübsch', lang: 'ger' },
+        { text: 'lovely', lang: 'en' },
+      ],
+    };
+    expect(getEnglishGlosses(sense)).toEqual(['cute', 'adorable', 'lovely']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #187 – Sense ordering: getSenseCommonness
+//
+// Before the fix, getSenseCommonness only scanned gloss *text* for strings like
+// "rare" or "archaic". JMDict encodes those markers in a structured `misc` array
+// (e.g. misc: ['sl'] for slang, misc: ['arch'] for archaic). Because the old code
+// never read sense.misc, slang / archaic senses scored identically to everyday
+// senses and could sort to the top.
+//
+// Real examples that were broken:
+//   猫 (neko) – first JMDict sense is unmarked "cat", second has misc:['sl']
+//     "submissive partner". Old code: tied score → both could surface as primary.
+//   桜 (sakura) – "hired applauder" sense has misc:['arch'].
+//   可愛い (kawaii) – "cute/adorable" sense should outscore "dainty/tiny".
+// ---------------------------------------------------------------------------
+
+describe('getSenseCommonness – #187 slang / archaic detection', () => {
+  it('gives lower score to a slang sense (misc: ["sl"])', () => {
+    const slangSense = {
+      gloss: [{ text: 'submissive partner (in a male-male relationship)', lang: 'en' }],
+      misc: ['sl'],
+    };
+    const commonSense = {
+      gloss: [{ text: 'cat', lang: 'en' }],
+      misc: [],
+    };
+    expect(getSenseCommonness(slangSense)).toBeLessThan(getSenseCommonness(commonSense));
+  });
+
+  it('gives lower score to an archaic sense (misc: ["arch"])', () => {
+    const archaicSense = {
+      gloss: [{ text: 'hired applauder', lang: 'en' }],
+      misc: ['arch'],
+    };
+    const commonSense = {
+      gloss: [{ text: 'cherry blossom', lang: 'en' }],
+      misc: [],
+    };
+    expect(getSenseCommonness(archaicSense)).toBeLessThan(getSenseCommonness(commonSense));
+  });
+
+  it('gives lower score to an obsolete sense (misc: ["obs"])', () => {
+    const obsSense = { gloss: [{ text: 'old usage', lang: 'en' }], misc: ['obs'] };
+    const normalSense = { gloss: [{ text: 'normal usage', lang: 'en' }], misc: [] };
+    expect(getSenseCommonness(obsSense)).toBeLessThan(getSenseCommonness(normalSense));
+  });
+
+  it('gives lower score to a rare sense (misc: ["rare"])', () => {
+    const rareSense = { gloss: [{ text: 'rare sense', lang: 'en' }], misc: ['rare'] };
+    const normalSense = { gloss: [{ text: 'cute', lang: 'en' }], misc: [] };
+    expect(getSenseCommonness(rareSense)).toBeLessThan(getSenseCommonness(normalSense));
+  });
+
+  it('gives lower score to vulgar / rude senses (misc: ["vulg"] / ["X"])', () => {
+    const vulgSense = { gloss: [{ text: 'rude term', lang: 'en' }], misc: ['vulg'] };
+    const xSense = { gloss: [{ text: 'x-rated term', lang: 'en' }], misc: ['X'] };
+    const normalSense = { gloss: [{ text: 'normal term', lang: 'en' }], misc: [] };
+    expect(getSenseCommonness(vulgSense)).toBeLessThan(getSenseCommonness(normalSense));
+    expect(getSenseCommonness(xSense)).toBeLessThan(getSenseCommonness(normalSense));
+  });
+
+  it('gives lower score to idiomatic senses that are domain-restricted', () => {
+    const domainSense = {
+      gloss: [{ text: 'technical computing term', lang: 'en' }],
+      misc: [],
+      field: ['comp'],
+    };
+    const commonSense = {
+      gloss: [{ text: 'common everyday word', lang: 'en' }],
+      misc: [],
+      field: [],
+    };
+    expect(getSenseCommonness(domainSense)).toBeLessThan(getSenseCommonness(commonSense));
+  });
+
+  it('gives higher score to senses with more English synonyms (well-established meanings)', () => {
+    // 可愛い: the "cute/adorable/sweet/charming" sense should beat the sparse "dainty" sense
+    const richSense = {
+      gloss: [
+        { text: 'cute', lang: 'en' },
+        { text: 'adorable', lang: 'en' },
+        { text: 'charming', lang: 'en' },
+      ],
+      misc: [],
+    };
+    const sparseSense = {
+      gloss: [{ text: 'dainty', lang: 'en' }],
+      misc: [],
+    };
+    expect(getSenseCommonness(richSense)).toBeGreaterThan(getSenseCommonness(sparseSense));
+  });
+
+  it('plain senses with no misc markers score >= 0', () => {
+    const plain = { gloss: [{ text: 'cat', lang: 'en' }], misc: [] };
+    expect(getSenseCommonness(plain)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('slang sense penalty is large enough that extra glosses cannot compensate', () => {
+    // Even a slang sense with many synonyms should lose to a plain sense with one gloss
+    const slangWithManyGlosses = {
+      gloss: [
+        { text: 'slang term 1', lang: 'en' },
+        { text: 'slang term 2', lang: 'en' },
+        { text: 'slang term 3', lang: 'en' },
+        { text: 'slang term 4', lang: 'en' },
+      ],
+      misc: ['sl'],
+    };
+    const plainOneSense = {
+      gloss: [{ text: 'cat', lang: 'en' }],
+      misc: [],
+    };
+    expect(getSenseCommonness(slangWithManyGlosses)).toBeLessThan(getSenseCommonness(plainOneSense));
+  });
+});

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -206,50 +206,57 @@ export class JishoApiDictionary implements Dictionary {
 // ==================== JMDict Helpers (exported for testing) ====================
 
 // ==================== JMDict Helpers (exported for testing) ====================
-// NOTE: These functions are exported so they can be unit-tested in dictionary.test.ts.
-// The tests below currently FAIL — they document the correct behaviour that the
-// existing implementation does not yet satisfy (TDD red state).
 
 /**
- * Returns the English-language gloss strings from a JMDict sense.
+ * Returns only the English-language gloss strings from a JMDict sense.
  *
- * BUG (#186 — not yet fixed): the fallback below returns the first gloss
- * regardless of language. If a sense has only German or Spanish glosses this
- * will return non-English text as a definition.
+ * Fix for #186: the original code had an `else if (sense.gloss[0]?.text)` fallback
+ * that pushed the first gloss without a language check. JMDict entries include
+ * German (ger), Spanish (spa), and other language glosses, so that fallback could
+ * return non-English text as a word's primary definition.
  */
 export function getEnglishGlosses(sense: any): string[] {
-  const filtered = ((sense.gloss as any[]) || [])
+  return ((sense.gloss as any[]) || [])
     .filter((g) => g.lang === "en")
     .map((g) => g.text)
     .filter(Boolean);
-  if (filtered.length > 0) return filtered;
-  // BUG: falls back to first gloss without checking language (original behaviour)
-  return sense.gloss?.[0]?.text ? [sense.gloss[0].text] : [];
 }
 
 /**
  * Scores a JMDict sense by how "common" / everyday it is.
  *
- * BUG (#187 — not yet fixed): this only scans the gloss *text* for words like
- * "rare" or "archaic". JMDict encodes register in a structured `misc` array
- * (e.g. misc:['sl'] for slang, misc:['arch'] for archaic) which this function
- * never reads, so slang/archaic senses score identically to common senses.
+ * Fix for #187: the original implementation only scanned gloss *text* for strings
+ * like "rare" or "archaic", completely missing JMDict's structured `misc` array.
+ * JMDict editors mark register in misc[], e.g.:
+ *   sl=slang, arch=archaic, obs=obsolete, rare=rare, vulg=vulgar,
+ *   derog=derogatory, X=rude/X-rated, id=idiomatic
+ * Because misc[] was never read, senses like 猫→"submissive partner" (sl) and
+ * 桜→"hired applauder" (arch) scored identically to plain everyday meanings and
+ * could sort to the top as the primary definition.
  */
 export function getSenseCommonness(sense: any): number {
   let score = 0;
+  const misc: string[] = sense.misc || [];
 
-  // BUG: checks gloss text, not sense.misc[] — misses the structured JMDict markers
-  if (sense.gloss && Array.isArray(sense.gloss) && sense.gloss.length > 1) {
-    score += 5;
+  // Heavy penalty for any explicit register/usage marker. -50 is intentionally
+  // large so that even a slang sense with multiple glosses (which earns a +5/+10
+  // bonus below) still ranks well below a single-gloss plain sense.
+  const uncommonMarkers = ['sl', 'arch', 'obs', 'rare', 'vulg', 'derog', 'X', 'id'];
+  if (misc.some((m) => uncommonMarkers.includes(m))) {
+    score -= 50;
   }
-  const gloss = sense.gloss?.[0]?.text || '';
-  const specializedTerms = ['esp.', 'rare', 'archaic', 'obsolete', 'old', 'dated', 'specialized'];
-  if (specializedTerms.some(term => gloss.toLowerCase().includes(term))) {
+
+  // Mild penalty for domain-restricted senses (e.g. computing, music). These
+  // are legitimate meanings but rarely what a beginner is looking for.
+  if (sense.field && Array.isArray(sense.field) && sense.field.length > 0) {
     score -= 10;
   }
-  if (gloss.toLowerCase().includes('copula') || gloss.toLowerCase().includes('auxiliary')) {
-    score += 3;
-  }
+
+  // Bonus for senses with multiple English synonyms: JMDict editors add more
+  // glosses for well-established, high-frequency meanings.
+  const enGlosses = getEnglishGlosses(sense);
+  if (enGlosses.length > 1) score += 5;
+  if (enGlosses.length > 2) score += 5;
 
   return score;
 }
@@ -320,16 +327,12 @@ export class JmdictDictionary implements Dictionary {
       sensesWithScores.sort((a, b) => b.commonness - a.commonness);
 
       for (const { sense } of sensesWithScores) {
-        if (sense.gloss && sense.gloss.length > 0) {
-          const glossTexts = (sense.gloss as any[])
-            .filter((g) => g.lang === "en")
-            .map((g) => g.text);
-          if (glossTexts.length > 0) {
-            meanings.push(...glossTexts);
-          } else if (sense.gloss[0]?.text) {
-            // BUG (#186): pushes first gloss without language check — can be German/Spanish
-            meanings.push(sense.gloss[0].text);
-          }
+        // getEnglishGlosses() only returns lang:"en" entries, so non-English
+        // JMDict senses are silently skipped rather than leaking German/Spanish
+        // text as definitions (fix for #186).
+        const glossTexts = getEnglishGlosses(sense);
+        if (glossTexts.length > 0) {
+          meanings.push(...glossTexts);
         }
       }
 
@@ -353,8 +356,8 @@ export class JmdictDictionary implements Dictionary {
     return score;
   }
 
-  // Delegates to the top-level exported getSenseCommonness so the logic is
-  // unit-testable without instantiating the class or touching the database.
+  // Delegates to the module-level getSenseCommonness so the logic can be
+  // unit-tested without instantiating the class or touching the database.
   private getSenseCommonness(sense: any): number {
     return getSenseCommonness(sense);
   }

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -203,6 +203,57 @@ export class JishoApiDictionary implements Dictionary {
   }
 }
 
+// ==================== JMDict Helpers (exported for testing) ====================
+
+// ==================== JMDict Helpers (exported for testing) ====================
+// NOTE: These functions are exported so they can be unit-tested in dictionary.test.ts.
+// The tests below currently FAIL — they document the correct behaviour that the
+// existing implementation does not yet satisfy (TDD red state).
+
+/**
+ * Returns the English-language gloss strings from a JMDict sense.
+ *
+ * BUG (#186 — not yet fixed): the fallback below returns the first gloss
+ * regardless of language. If a sense has only German or Spanish glosses this
+ * will return non-English text as a definition.
+ */
+export function getEnglishGlosses(sense: any): string[] {
+  const filtered = ((sense.gloss as any[]) || [])
+    .filter((g) => g.lang === "en")
+    .map((g) => g.text)
+    .filter(Boolean);
+  if (filtered.length > 0) return filtered;
+  // BUG: falls back to first gloss without checking language (original behaviour)
+  return sense.gloss?.[0]?.text ? [sense.gloss[0].text] : [];
+}
+
+/**
+ * Scores a JMDict sense by how "common" / everyday it is.
+ *
+ * BUG (#187 — not yet fixed): this only scans the gloss *text* for words like
+ * "rare" or "archaic". JMDict encodes register in a structured `misc` array
+ * (e.g. misc:['sl'] for slang, misc:['arch'] for archaic) which this function
+ * never reads, so slang/archaic senses score identically to common senses.
+ */
+export function getSenseCommonness(sense: any): number {
+  let score = 0;
+
+  // BUG: checks gloss text, not sense.misc[] — misses the structured JMDict markers
+  if (sense.gloss && Array.isArray(sense.gloss) && sense.gloss.length > 1) {
+    score += 5;
+  }
+  const gloss = sense.gloss?.[0]?.text || '';
+  const specializedTerms = ['esp.', 'rare', 'archaic', 'obsolete', 'old', 'dated', 'specialized'];
+  if (specializedTerms.some(term => gloss.toLowerCase().includes(term))) {
+    score -= 10;
+  }
+  if (gloss.toLowerCase().includes('copula') || gloss.toLowerCase().includes('auxiliary')) {
+    score += 3;
+  }
+
+  return score;
+}
+
 // ==================== JMDict Wrapper Dictionary ====================
 export class JmdictDictionary implements Dictionary {
   private db: any = null;
@@ -276,6 +327,7 @@ export class JmdictDictionary implements Dictionary {
           if (glossTexts.length > 0) {
             meanings.push(...glossTexts);
           } else if (sense.gloss[0]?.text) {
+            // BUG (#186): pushes first gloss without language check — can be German/Spanish
             meanings.push(sense.gloss[0].text);
           }
         }
@@ -294,49 +346,17 @@ export class JmdictDictionary implements Dictionary {
   }
 
   private getEntryCommonness(entry: any): number {
-    // Score entries by how "common" they appear
     let score = 0;
-
-    // Prefer entries with kanji (more concrete words)
-    if (entry.kanji && entry.kanji.length > 0) {
-      score += 10;
-    }
-
-    // Prefer entries with multiple kanji variants (widely used)
-    if (entry.kanji && entry.kanji.length > 1) {
-      score += 5;
-    }
-
-    // Prefer entries with multiple senses (more established)
-    if (entry.sense && entry.sense.length > 1) {
-      score += 3;
-    }
-
+    if (entry.kanji && entry.kanji.length > 0) score += 10;
+    if (entry.kanji && entry.kanji.length > 1) score += 5;
+    if (entry.sense && entry.sense.length > 1) score += 3;
     return score;
   }
 
+  // Delegates to the top-level exported getSenseCommonness so the logic is
+  // unit-testable without instantiating the class or touching the database.
   private getSenseCommonness(sense: any): number {
-    // Score senses by how "common" they are
-    let score = 0;
-
-    // Prefer senses with multiple glosses (well-established meanings)
-    if (sense.gloss && Array.isArray(sense.gloss) && sense.gloss.length > 1) {
-      score += 5;
-    }
-
-    // Penalize specialized meanings
-    const gloss = sense.gloss?.[0]?.text || '';
-    const specializedTerms = ['esp.', 'rare', 'archaic', 'obsolete', 'old', 'dated', 'specialized'];
-    if (specializedTerms.some(term => gloss.toLowerCase().includes(term))) {
-      score -= 10;
-    }
-
-    // Prefer common grammatical terms
-    if (gloss.toLowerCase().includes('copula') || gloss.toLowerCase().includes('auxiliary')) {
-      score += 3;
-    }
-
-    return score;
+    return getSenseCommonness(sense);
   }
 }
 

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -267,13 +267,23 @@ export class JmdictDictionary implements Dictionary {
   private initialized = false;
   private readingAnywhere: any = null;
   private kanjiAnywhere: any = null;
+  private readingBeginning: any = null;
+  private kanjiBeginning: any = null;
 
   async initialize(jmdictPath: string, jmdictFile: string): Promise<void> {
     try {
       const require = createRequire(import.meta.url);
-      const { setup: setupJmdict, readingAnywhere, kanjiAnywhere } = require("jmdict-wrapper");
+      const {
+        setup: setupJmdict,
+        readingAnywhere,
+        kanjiAnywhere,
+        readingBeginning,
+        kanjiBeginning,
+      } = require("jmdict-wrapper");
       this.readingAnywhere = readingAnywhere;
       this.kanjiAnywhere = kanjiAnywhere;
+      this.readingBeginning = readingBeginning;
+      this.kanjiBeginning = kanjiBeginning;
 
       const result = await setupJmdict(jmdictPath, jmdictFile, false);
       this.db = result.db;
@@ -290,32 +300,42 @@ export class JmdictDictionary implements Dictionary {
   }
 
   async lookup(word: string): Promise<WordLookupResult | null> {
-    if (!this.db || !this.readingAnywhere || !this.kanjiAnywhere) return null;
+    if (!this.db || !this.readingBeginning || !this.kanjiBeginning) return null;
 
     try {
-      let results: any[] = await this.readingAnywhere(this.db, word, 10);
-      if (results.length === 0) {
-        results = await this.kanjiAnywhere(this.db, word, 10);
-      }
-      if (results.length === 0) return null;
+      // Use the exact-form indexes (indexes/kana/{word}-* and indexes/kanji/{word}-*)
+      // rather than the partial indexes. The partial scan (readingAnywhere / kanjiAnywhere)
+      // is limited to 20 results and may miss the target entry when many other words
+      // contain the search string as a substring (e.g. 'いい' in おおきい, etc.).
+      // readingBeginning / kanjiBeginning scan the prefix-keyed exact-form index which
+      // only returns entries where the kana/kanji text STARTS WITH the search word, so
+      // we then filter to exact matches. No artificial result limit needed here.
+      const [readingCandidates, kanjiCandidates] = await Promise.all([
+        this.readingBeginning(this.db, word, -1),
+        this.kanjiBeginning(this.db, word, -1),
+      ]);
 
-      // Find best match: prioritize entries with exact kana/kanji match + common words
-      let bestMatch = results.find(
+      const allCandidates = [...readingCandidates, ...kanjiCandidates];
+
+      // Keep only entries where a kana or kanji text is EXACTLY the search word.
+      const exactMatches = allCandidates.filter(
         (r) =>
           r.kana.some((k: any) => k.text === word) ||
           r.kanji.some((k: any) => k.text === word)
       );
 
-      // If no exact match, score all results by commonness
-      if (!bestMatch) {
-        bestMatch = results.reduce((best: any, current: any) => {
-          const bestScore = this.getEntryCommonness(best);
-          const currentScore = this.getEntryCommonness(current);
-          return currentScore > bestScore ? current : best;
-        });
-      }
+      if (exactMatches.length === 0) return null;
 
-      // Extract all meanings (prioritize more common senses)
+      // Among exact matches, pick the entry with the most senses (most complete entry).
+      // For words like 行く that have multiple variants (行く, 往く), all exact matches
+      // refer to the same underlying word — pick the most common entry.
+      const bestMatch = exactMatches.reduce((best: any, current: any) => {
+        const bestScore = this.getEntryCommonness(best);
+        const currentScore = this.getEntryCommonness(current);
+        return currentScore > bestScore ? current : best;
+      });
+
+      // Extract all meanings, deprioritising rare/slang/archaic senses (#187).
       const meanings: string[] = [];
       const sensesWithScores = (bestMatch.sense || []).map((sense: any, idx: number) => ({
         sense,
@@ -323,8 +343,11 @@ export class JmdictDictionary implements Dictionary {
         commonness: this.getSenseCommonness(sense)
       }));
 
-      // Sort by commonness (higher first)
-      sensesWithScores.sort((a, b) => b.commonness - a.commonness);
+      // Sort by commonness descending; use original order as tiebreaker.
+      sensesWithScores.sort((a, b) => {
+        const diff = b.commonness - a.commonness;
+        return diff !== 0 ? diff : a.order - b.order;
+      });
 
       for (const { sense } of sensesWithScores) {
         // getEnglishGlosses() only returns lang:"en" entries, so non-English
@@ -336,10 +359,13 @@ export class JmdictDictionary implements Dictionary {
         }
       }
 
-      const meaning = meanings[0] || "Unknown";
+      // Return null when no English meanings were found — this lets DictionaryManager
+      // try the fallback chain (JMnedict → Jisho) rather than returning "Unknown".
+      if (meanings.length === 0) return null;
+
       return {
-        meaning,
-        meanings: meanings.length > 0 ? meanings : undefined,
+        meaning: meanings[0],
+        meanings: meanings.length > 1 ? meanings : undefined,
         reading: bestMatch.kana[0]?.text || word,
       };
     } catch (e) {

--- a/src/lib/morphemeDefinitions.ts
+++ b/src/lib/morphemeDefinitions.ts
@@ -14,12 +14,18 @@ export const morphemeDefinitions: Record<string, string> = {
   せ: "Causative passive",
   ん: "Negative form / Emphatic particle",
   ぬ: "Negative form (classical)",
-  ない: "Negative form",
-  なかった: "Past negative",
+  ない: "not; negative form",
+  なかった: "was not; past negative",
+
+  // Copula and auxiliary verbs
+  です: "polite copula; to be (is/are)",
+  でした: "polite past copula; was/were",
 
   // Auxiliary verbs and endings
-  ます: "Polite form marker",
-  ました: "Past polite form",
+  ます: "polite verb ending (non-past)",
+  ました: "polite past form",
+  まし: "Polite verb stem (masu-stem form)",
+  たい: "want to (do something); desiderative auxiliary",
   なさい: "Imperative form",
 
   // Honorific/humble prefixes

--- a/tests/test-dictionary-quality.ts
+++ b/tests/test-dictionary-quality.ts
@@ -1,0 +1,357 @@
+/**
+ * Dictionary Quality Integration Tests (#191)
+ *
+ * Tests the full pipeline against the real JMDict and Sudachi tokenizer to catch
+ * the concrete issues identified in GitHub issues #186, #187, #188, #189.
+ *
+ * Run:  npx tsx tests/test-dictionary-quality.ts
+ *
+ * Requirements:
+ *   - jmdict-all-3.6.2.json.tgz must be present (auto-extracted by this script)
+ *   - sudachi-wasm-built/ must be present (built by npm install / npm run setup-sudachi)
+ *
+ * Each test section prints PASS / FAIL with the actual result so you can re-run
+ * before and after a fix to confirm the fix works.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import * as tar from 'tar';
+import { fileURLToPath } from 'url';
+import { JmdictDictionary } from '../src/lib/dictionary.js';
+import { createTokenizer } from '../src/lib/tokenizers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean, detail?: string) {
+  if (condition) {
+    console.log(`  ✅ PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  ❌ FAIL  ${label}${detail ? `\n         → ${detail}` : ''}`);
+    failed++;
+  }
+}
+
+function assertContains(label: string, value: string, expected: string) {
+  assert(label, value.toLowerCase().includes(expected.toLowerCase()),
+    `got "${value}", expected it to contain "${expected}"`);
+}
+
+function assertNotContains(label: string, value: string, unexpected: string) {
+  assert(label, !value.toLowerCase().includes(unexpected.toLowerCase()),
+    `got "${value}", but it should NOT contain "${unexpected}"`);
+}
+
+function section(title: string) {
+  console.log(`\n${'─'.repeat(70)}`);
+  console.log(`  ${title}`);
+  console.log('─'.repeat(70));
+}
+
+// ---------------------------------------------------------------------------
+// Setup: extract JMDict if needed
+// ---------------------------------------------------------------------------
+
+async function ensureJmdict(): Promise<boolean> {
+  const jsonFile = path.join(ROOT, 'jmdict-all-3.6.2.json');
+  const tgzFile  = path.join(ROOT, 'jmdict-all-3.6.2.json.tgz');
+
+  if (fs.existsSync(jsonFile)) return true;
+
+  if (!fs.existsSync(tgzFile)) {
+    console.warn('[Setup] jmdict-all-3.6.2.json.tgz not found — skipping JMDict tests');
+    return false;
+  }
+
+  console.log('[Setup] Extracting JMDict (this takes ~10 s the first time)…');
+  await tar.extract({ file: tgzFile, cwd: ROOT });
+  console.log('[Setup] JMDict extracted');
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+async function runTests() {
+  console.log('='.repeat(70));
+  console.log('  Dictionary Quality Tests  (issues #186, #187, #188, #189, #191)');
+  console.log('='.repeat(70));
+
+  const jmdictAvailable = await ensureJmdict();
+
+  // -------------------------------------------------------------------------
+  // 1. JMDict – #186: No non-English definitions should leak through
+  // -------------------------------------------------------------------------
+  section('#186 — JMDict lookup returns only English definitions');
+
+  if (!jmdictAvailable) {
+    console.log('  ⚠️  SKIP (JMDict not available)');
+  } else {
+    const jmdict = new JmdictDictionary();
+    await jmdict.initialize(path.join(ROOT, 'jmdict-db'), path.join(ROOT, 'jmdict-all-3.6.2.json'));
+
+    if (!jmdict.isInitialized()) {
+      console.log('  ⚠️  SKIP (JMDict failed to initialize)');
+    } else {
+      // Words that have non-English senses in JMDict alongside English ones.
+      // Before the fix the fallback `else if (sense.gloss[0]?.text)` could
+      // return German / Spanish text for senses with no English glosses.
+      const wordsToCheck = ['猫', '桜', '犬', '水', '食べる', 'です', '走る'];
+
+      for (const word of wordsToCheck) {
+        const result = await jmdict.lookup(word);
+        if (!result) {
+          console.log(`  ⚠️  SKIP "${word}" (not found in JMDict)`);
+          continue;
+        }
+
+        const allDefs = [result.meaning, ...(result.meanings || [])].join(' | ');
+
+        // Spot-check: German words from JMDict ger-lang entries
+        assertNotContains(`"${word}" meaning not in German`, allDefs, 'die ');
+        assertNotContains(`"${word}" meaning not in Spanish (no "el " prefix)`, allDefs, ' el ');
+
+        // All glosses should be recognisably Latin-script English, not e.g. Japanese
+        const hasNonAsciiNonJapanese = /[À-ÿ]/.test(allDefs); // accented Latin chars common in European langs
+        assert(`"${word}" definitions use plain ASCII/English characters`, !hasNonAsciiNonJapanese,
+          `definitions contain non-ASCII Latin chars: "${allDefs}"`);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. JMDict – #187: Common words get their common meaning first
+  // -------------------------------------------------------------------------
+  section('#187 — Common words return everyday meaning, not rare/slang/archaic');
+
+  if (!jmdictAvailable) {
+    console.log('  ⚠️  SKIP (JMDict not available)');
+  } else {
+    const jmdict = new JmdictDictionary();
+    await jmdict.initialize(path.join(ROOT, 'jmdict-db'), path.join(ROOT, 'jmdict-all-3.6.2.json'));
+
+    if (!jmdict.isInitialized()) {
+      console.log('  ⚠️  SKIP (JMDict failed to initialize)');
+    } else {
+      // 猫 (neko) – should be "cat", NOT "submissive partner" (misc:['sl'])
+      const neko = await jmdict.lookup('猫');
+      assert('猫 (neko) is found', !!neko, 'not found in JMDict');
+      if (neko) {
+        assertContains('猫 primary meaning contains "cat"', neko.meaning, 'cat');
+        assertNotContains('猫 primary meaning is not the slang sense', neko.meaning, 'submissive');
+      }
+
+      // 桜 (sakura) – should be "cherry blossom", NOT "hired applauder" (misc:['arch'])
+      const sakura = await jmdict.lookup('桜');
+      assert('桜 (sakura) is found', !!sakura, 'not found in JMDict');
+      if (sakura) {
+        assertContains('桜 primary meaning contains "cherry"', sakura.meaning, 'cherry');
+        assertNotContains('桜 primary meaning is not the archaic sense', sakura.meaning, 'applaud');
+      }
+
+      // 可愛い (kawaii) – "cute/adorable" should beat "dainty/tiny"
+      const kawaii = await jmdict.lookup('可愛い');
+      assert('可愛い (kawaii) is found', !!kawaii, 'not found in JMDict');
+      if (kawaii) {
+        // "cute" should appear somewhere in the first few meanings
+        const topMeanings = (kawaii.meanings || [kawaii.meaning]).slice(0, 4).join(' ').toLowerCase();
+        assert('可愛い top meanings include "cute" or "adorable"',
+          topMeanings.includes('cute') || topMeanings.includes('adorable'),
+          `top meanings: "${topMeanings}"`);
+        // Primary meaning should NOT be "dainty" or "tiny" (those were the wrong results)
+        assertNotContains('可愛い primary meaning is not "dainty"', kawaii.meaning, 'dainty');
+      }
+
+      // 犬 (inu) – should be "dog"
+      const inu = await jmdict.lookup('犬');
+      assert('犬 (inu) is found', !!inu, 'not found in JMDict');
+      if (inu) {
+        assertContains('犬 primary meaning contains "dog"', inu.meaning, 'dog');
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. JMDict – #188: Common grammar words (です, ます, etc.) are found
+  //
+  // Before the fix, /api/word/:word only used getCachedDictionaryEntries (kanji-data)
+  // and never called the dictionary for kana-only words. This is tested here at
+  // the JMDict layer; the full API consistency fix is in server.ts.
+  // -------------------------------------------------------------------------
+  section('#188 — Grammar words (kana-only) are found in JMDict');
+
+  if (!jmdictAvailable) {
+    console.log('  ⚠️  SKIP (JMDict not available)');
+  } else {
+    const jmdict = new JmdictDictionary();
+    await jmdict.initialize(path.join(ROOT, 'jmdict-db'), path.join(ROOT, 'jmdict-all-3.6.2.json'));
+
+    if (!jmdict.isInitialized()) {
+      console.log('  ⚠️  SKIP (JMDict failed to initialize)');
+    } else {
+      const grammarWords: [string, string][] = [
+        ['です', 'be'],          // copula – should find "to be" or "is/are"
+        ['ます', 'polite'],      // polite form marker
+        ['ない', 'not'],         // negative auxiliary
+        ['ている', 'progressive'], // te-iru progressive
+        ['から', 'from'],        // particle / conjunction
+        ['ので', 'because'],     // reason conjunction
+      ];
+
+      for (const [word, hint] of grammarWords) {
+        const result = await jmdict.lookup(word);
+        assert(`"${word}" is found in JMDict`, !!result,
+          'not found — this is the root cause of "Unknown meaning" on the word detail page');
+        if (result) {
+          const allText = [result.meaning, ...(result.meanings || [])].join(' ').toLowerCase();
+          assert(`"${word}" definition mentions "${hint}"`,
+            allText.includes(hint),
+            `got "${result.meaning}"`);
+        }
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Tokenizer – #189: Sudachi splits sentences and provides base forms
+  //
+  // This section tokenizes real Japanese sentences and checks:
+  //   a) The sentence is split into recognisable morphemes
+  //   b) baseForm is the dictionary/citation form (not the conjugated surface)
+  //
+  // We do NOT assert that dictionary lookup succeeds for conjugated forms here —
+  // that depends on whether Sudachi mode C, B, or A is used (see issue #189).
+  // Instead we print the tokenization output so you can compare modes visually.
+  // -------------------------------------------------------------------------
+  section('#189 — Tokenizer produces baseForm for conjugated verbs');
+
+  let tokenizer: any = null;
+  try {
+    tokenizer = await createTokenizer('sudachi-wasm');
+    console.log(`  Tokenizer: ${tokenizer.name}`);
+  } catch (e) {
+    console.log(`  ⚠️  SKIP (Sudachi WASM not available: ${(e as Error).message})`);
+  }
+
+  if (tokenizer) {
+    // Sentence: "猫が寝ています。" (The cat is sleeping.)
+    const sentence1 = '猫が寝ています。';
+    const tokens1 = await tokenizer.segment(sentence1);
+    console.log(`\n  Input: "${sentence1}"`);
+    console.log('  Tokens:');
+    for (const t of tokens1) {
+      const baseDiff = t.baseForm !== t.surface ? ` → baseForm: "${t.baseForm}"` : '';
+      console.log(`    "${t.surface}"${baseDiff}`);
+    }
+
+    // We expect to find 猫 and some form of 寝る
+    const surfaces = tokens1.map((t: any) => t.surface);
+    const baseForms = tokens1.map((t: any) => t.baseForm);
+    assert('sentence 1 contains 猫', surfaces.includes('猫'), `tokens: ${surfaces.join(', ')}`);
+    // baseForm of the verb token containing 寝 should be 寝る
+    const hasNeruBase = baseForms.some((b: string) => b === '寝る' || b.includes('寝'));
+    assert('sentence 1 has a token with baseForm containing 寝る',
+      hasNeruBase, `baseForms: ${baseForms.join(', ')}`);
+
+    // Sentence: "田中さんは東京に住んでいます。" (Mr. Tanaka lives in Tokyo.)
+    const sentence2 = '田中さんは東京に住んでいます。';
+    const tokens2 = await tokenizer.segment(sentence2);
+    console.log(`\n  Input: "${sentence2}"`);
+    console.log('  Tokens:');
+    for (const t of tokens2) {
+      const baseDiff = t.baseForm !== t.surface ? ` → baseForm: "${t.baseForm}"` : '';
+      console.log(`    "${t.surface}"${baseDiff}`);
+    }
+    const baseForms2 = tokens2.map((t: any) => t.baseForm);
+    const hasSumuBase = baseForms2.some((b: string) => b === '住む' || b.includes('住'));
+    assert('sentence 2 has a token with baseForm containing 住む',
+      hasSumuBase, `baseForms: ${baseForms2.join(', ')}`);
+
+    // Sentence: "可愛い猫が好きです。" (I like cute cats.)
+    const sentence3 = '可愛い猫が好きです。';
+    const tokens3 = await tokenizer.segment(sentence3);
+    console.log(`\n  Input: "${sentence3}"`);
+    console.log('  Tokens:');
+    for (const t of tokens3) {
+      const baseDiff = t.baseForm !== t.surface ? ` → baseForm: "${t.baseForm}"` : '';
+      console.log(`    "${t.surface}"${baseDiff}`);
+    }
+    const surfaces3 = tokens3.map((t: any) => t.surface);
+    assert('sentence 3 contains 猫', surfaces3.includes('猫'),
+      `tokens: ${surfaces3.join(', ')}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Tokenizer – Sudachi mode comparison (see issue #189)
+  //
+  // Shows mode A, B, C output side by side for the same sentence so we can
+  // evaluate the tradeoff before deciding whether to change the default mode.
+  // -------------------------------------------------------------------------
+  section('#189 — Sudachi mode A vs B vs C comparison (informational)');
+
+  if (!tokenizer) {
+    console.log('  ⚠️  SKIP (Sudachi WASM not available)');
+  } else {
+    const testSentence = '猫が寝ています。田中さんは走りました。';
+    console.log(`\n  Sentence: "${testSentence}"\n`);
+
+    for (const mode of ['A', 'B', 'C'] as const) {
+      try {
+        const morphemes = (tokenizer as any).tokenizer?.run(testSentence, mode);
+        if (!morphemes) { console.log(`  Mode ${mode}: tokenizer.run() returned null`); continue; }
+
+        const tokens = morphemes
+          .filter((m: any) => m.part_of_speech[0] !== '補助記号' && !/^\s+$/.test(m.surface))
+          .map((m: any) => ({
+            surface: m.surface,
+            base: m.normalized_form || m.surface,
+          }));
+
+        const tokenStr = tokens.map((t: any) =>
+          t.base !== t.surface ? `${t.surface}(→${t.base})` : t.surface
+        ).join(' | ');
+
+        console.log(`  Mode ${mode}: ${tokenStr}`);
+      } catch (e) {
+        console.log(`  Mode ${mode}: ERROR — ${(e as Error).message}`);
+      }
+    }
+
+    console.log(`
+  Notes for #189:
+    Mode C (current default): groups verb stems + auxiliaries into one token.
+      Pro: "寝ています" as one unit is readable / hover-tooltip friendly.
+      Con: "寝ています" is not in the dictionary; base form lookup fails.
+    Mode A: maximum granularity. Each morpheme is separate with its own base form.
+      Pro: every token can be looked up individually.
+      Con: beginners see "て" and "い" and "ます" as separate "words" to hover.
+    Mode B: intermediate. Worth testing.
+  Decision: do NOT change the default mode yet; evaluate after seeing the output above.
+`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Summary
+  // -------------------------------------------------------------------------
+  console.log('='.repeat(70));
+  const total = passed + failed;
+  console.log(`  Results: ${passed}/${total} passed, ${failed} failed`);
+  console.log('='.repeat(70));
+
+  if (failed > 0) process.exit(1);
+}
+
+runTests().catch((e) => {
+  console.error('Test runner error:', e);
+  process.exit(1);
+});

--- a/tests/test-server-api.ts
+++ b/tests/test-server-api.ts
@@ -1,0 +1,311 @@
+/**
+ * Server API Integration Tests
+ *
+ * Tests the real Express server endpoints against the 10 known failure cases
+ * identified in the GitHub issues. Run after starting the server:
+ *
+ *   npm run dev   (in a separate terminal)
+ *   npx tsx tests/test-server-api.ts
+ *
+ * Each test prints PASS / FAIL with the actual result received from the server.
+ */
+
+import { execSync } from 'child_process';
+
+const SERVER_URL = process.env.SERVER_URL || 'http://localhost:3000';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean, detail?: string) {
+  if (condition) {
+    console.log(`  ✅ PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  ❌ FAIL  ${label}${detail ? `\n         → ${detail}` : ''}`);
+    failed++;
+  }
+}
+
+function assertContains(label: string, value: string, expected: string) {
+  assert(
+    label,
+    value.toLowerCase().includes(expected.toLowerCase()),
+    `got "${value}", expected it to contain "${expected}"`
+  );
+}
+
+function assertNotContains(label: string, value: string, unexpected: string) {
+  assert(
+    label,
+    !value.toLowerCase().includes(unexpected.toLowerCase()),
+    `got "${value}", but it should NOT contain "${unexpected}"`
+  );
+}
+
+function section(title: string) {
+  console.log(`\n${'─'.repeat(70)}`);
+  console.log(`  ${title}`);
+  console.log('─'.repeat(70));
+}
+
+function curlPost(path: string, body: Record<string, string>): any {
+  const bodyJson = JSON.stringify(body).replace(/'/g, "'\\''");
+  const cmd = `curl -sf --max-time 30 -X POST '${SERVER_URL}${path}' -H 'Content-Type: application/json' -d '${bodyJson}'`;
+  try {
+    const out = execSync(cmd, { encoding: 'utf8', timeout: 35000 });
+    return JSON.parse(out);
+  } catch (e: any) {
+    throw new Error(`Request to ${path} failed: ${e.message}`);
+  }
+}
+
+function curlGet(path: string): any {
+  const cmd = `curl -sf --max-time 15 '${SERVER_URL}${path}'`;
+  try {
+    const out = execSync(cmd, { encoding: 'utf8', timeout: 20000 });
+    return JSON.parse(out);
+  } catch (e: any) {
+    throw new Error(`Request to ${path} failed: ${e.message}`);
+  }
+}
+
+function serverIsUp(): boolean {
+  try {
+    execSync(`curl -sf --max-time 3 '${SERVER_URL}/'`, { stdio: 'pipe', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findWord(words: any[], target: string): any | undefined {
+  return words.find((w: any) => w.word === target);
+}
+
+function allMeanings(word: any): string {
+  const parts: string[] = [];
+  if (word.meaning) parts.push(word.meaning);
+  if (Array.isArray(word.meanings)) parts.push(...word.meanings);
+  return parts.join(' | ');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function runTests() {
+  console.log('='.repeat(70));
+  console.log('  Server API Tests — known failure cases');
+  console.log('='.repeat(70));
+
+  if (!serverIsUp()) {
+    console.log(`\n⚠️  Server is not running at ${SERVER_URL}`);
+    console.log('   Start it with:  npm run dev');
+    console.log('   Then re-run:   npx tsx tests/test-server-api.ts\n');
+    process.exit(0);
+  }
+
+  console.log(`\n  Connected to server at ${SERVER_URL}\n`);
+
+  // -----------------------------------------------------------------------
+  // 1. 猫 → "cat", not slang sense (issue #187)
+  // -----------------------------------------------------------------------
+  section('#187 — 猫 primary meaning is "cat", not slang "submissive partner"');
+  {
+    const words = curlPost('/api/extract', { text: '猫が寝ています。' });
+    const neko = findWord(words, '猫');
+    assert('猫 is returned by /api/extract', !!neko, 'word not found in response');
+    if (neko) {
+      assertContains('猫 primary meaning contains "cat"', neko.meaning, 'cat');
+      assertNotContains('猫 primary meaning is not the slang sense', neko.meaning, 'submissive');
+      assertNotContains('猫 primary meaning is not the slang sense', neko.meaning, 'homosexual');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 2. 寝る → "to sleep", not "to ferment" (issue #187 ordering)
+  // -----------------------------------------------------------------------
+  section('#187 — 寝 primary meaning is "to sleep", not "to ferment"');
+  {
+    const words = curlPost('/api/extract', { text: '猫が寝ています。' });
+    const ne = words.find((w: any) => w.word === '寝' || w.word === '寝る');
+    assert('寝/寝る is returned by /api/extract', !!ne,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (ne) {
+      assertContains('寝る primary meaning contains "sleep"', ne.meaning, 'sleep');
+      assertNotContains('寝る primary meaning is not "to ferment"', ne.meaning, 'ferment');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 3. 桜 → "cherry blossom", not "hired applauder" (issue #187)
+  // -----------------------------------------------------------------------
+  section('#187 — 桜 primary meaning is "cherry blossom", not "hired applauder"');
+  {
+    const words = curlPost('/api/extract', { text: '桜が咲いています。' });
+    const sakura = findWord(words, '桜');
+    assert('桜 is returned by /api/extract', !!sakura, 'word not found in response');
+    if (sakura) {
+      assertContains('桜 primary meaning contains "cherry"', sakura.meaning, 'cherry');
+      assertNotContains('桜 primary meaning is not archaic "applaud" sense', sakura.meaning, 'applaud');
+      assertNotContains('桜 primary meaning is not "horse meat"', sakura.meaning, 'horse meat');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 4. 買い → "to buy", not "paying for a prostitute" (issue #187 ordering)
+  // -----------------------------------------------------------------------
+  section('#187 — 買い primary meaning is "to buy", not "paying for a prostitute"');
+  {
+    const words = curlPost('/api/extract', { text: '本を買いました。' });
+    const kai = words.find((w: any) => w.word === '買い' || w.word === '買う');
+    assert('買い/買う is returned by /api/extract', !!kai,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (kai) {
+      assertContains('買い primary meaning contains "buy"', kai.meaning, 'buy');
+      assertNotContains('買い primary meaning not about prostitution', kai.meaning, 'prostitut');
+      assertNotContains('買い primary meaning not about geisha', kai.meaning, 'geisha');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 5. たい → "want to", not Dutch/foreign text (issues #186, #188)
+  // -----------------------------------------------------------------------
+  section('#186 / #188 — たい returns "want to", not foreign-language text');
+  {
+    const words = curlPost('/api/extract', { text: '海に行きたいです。' });
+    const tai = findWord(words, 'たい');
+    assert('たい is returned by /api/extract', !!tai,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (tai) {
+      assertNotContains('たい meaning is not "Unknown"', tai.meaning, 'Unknown');
+      assertContains('たい meaning contains "want"', tai.meaning, 'want');
+      // Before fix: Dutch "Kriebelen" from a non-English JMDict gloss
+      assertNotContains('たい meaning not in Dutch (no "kriebelen")', tai.meaning, 'kriebelen');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 6. いい → "good", not "Unknown" (issues #186, #188)
+  // -----------------------------------------------------------------------
+  section('#186 / #188 — いい returns "good / nice", not "Unknown" or German text');
+  {
+    const words = curlPost('/api/extract', { text: '今日はいい天気です。' });
+    const ii = findWord(words, 'いい');
+    assert('いい is returned by /api/extract', !!ii,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (ii) {
+      assertNotContains('いい meaning is not "Unknown"', ii.meaning, 'Unknown');
+      const hasGoodOrNice = ii.meaning.toLowerCase().includes('good') || ii.meaning.toLowerCase().includes('nice');
+      assert('いい meaning contains "good" or "nice"', hasGoodOrNice, `got: "${ii.meaning}"`);
+      // Before fix: German text from JMDict non-English glosses
+      assertNotContains('いい meaning is not in German', ii.meaning, 'gut ');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 7. まし → polite suffix sense, not "appalling" (issues #187, #188)
+  // -----------------------------------------------------------------------
+  section('#187 / #188 — まし is not "appalling" (polite verb stem)');
+  {
+    const words = curlPost('/api/extract', { text: '春が来ましたね。' });
+    const mashi = findWord(words, 'まし');
+    assert('まし is returned by /api/extract', !!mashi,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (mashi) {
+      assertNotContains('まし meaning is not "appalling"', mashi.meaning, 'appalling');
+      assertNotContains('まし meaning is not "terrible"', mashi.meaning, 'terrible');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 8. 春 → "spring (season)", not archaic "New Year" (issue #187)
+  // -----------------------------------------------------------------------
+  section('#187 — 春 primary meaning is "spring (season)", not archaic "New Year"');
+  {
+    const words = curlPost('/api/extract', { text: '春が来ましたね。' });
+    const haru = findWord(words, '春');
+    assert('春 is returned by /api/extract', !!haru, 'word not found in response');
+    if (haru) {
+      assertContains('春 primary meaning contains "spring"', haru.meaning, 'spring');
+      assertNotContains('春 primary meaning is not "New Year"', haru.meaning, 'New Year');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 9. 可愛い → "cute / adorable", not "dainty, little, tiny" (issue #187)
+  // -----------------------------------------------------------------------
+  section('#187 — 可愛い primary meaning is "cute/adorable", not "dainty/tiny"');
+  {
+    const words = curlPost('/api/extract', { text: 'とても可愛いです。' });
+    const kawaii = findWord(words, '可愛い');
+    assert('可愛い is returned by /api/extract', !!kawaii, 'word not found in response');
+    if (kawaii) {
+      const top = allMeanings(kawaii).toLowerCase().slice(0, 200);
+      assert('可愛い top meanings include "cute" or "adorable"',
+        top.includes('cute') || top.includes('adorable'),
+        `got: "${kawaii.meaning}"`);
+      assertNotContains('可愛い primary meaning is not "dainty"', kawaii.meaning, 'dainty');
+      assertNotContains('可愛い primary meaning is not "tiny"', kawaii.meaning, 'tiny');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 10. 行き → "to go", not "to die / pass away" (issue #187 ordering)
+  // -----------------------------------------------------------------------
+  section('#187 — 行き primary meaning is "to go", not "to die / pass away"');
+  {
+    const words = curlPost('/api/extract', { text: '行きました。' });
+    const iki = words.find((w: any) => w.word === '行き' || w.word === '行く');
+    assert('行き/行く is returned by /api/extract', !!iki,
+      `words returned: ${words.map((w: any) => w.word).join(', ')}`);
+    if (iki) {
+      assertContains('行き primary meaning contains "go"', iki.meaning, 'go');
+      assertNotContains('行き primary meaning is not "to die"', iki.meaning, 'to die');
+      assertNotContains('行き primary meaning is not "pass away"', iki.meaning, 'pass away');
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Bonus: /api/word/:word endpoint — kana words should have real meanings
+  // -----------------------------------------------------------------------
+  section('#188 — /api/word/:word endpoint: kana grammar words return real meanings');
+  {
+    for (const [word, expectedHint] of [
+      ['です', 'be'],
+      ['ます', 'polite'],
+      ['ない', 'not'],
+    ] as const) {
+      const encoded = encodeURIComponent(word);
+      const result = curlGet(`/api/word/${encoded}`);
+      assert(`/api/word/${word} returns a result`, !!result && !result.error,
+        result?.error || 'no result');
+      if (result && !result.error) {
+        assertNotContains(`/api/word/${word} meaning is not "Unknown"`, result.meaning || '', 'Unknown');
+        assertContains(`/api/word/${word} meaning mentions "${expectedHint}"`,
+          (result.meaning || '') + ' ' + (result.meanings || []).join(' '),
+          expectedHint);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Summary
+  // -------------------------------------------------------------------------
+  console.log('\n' + '='.repeat(70));
+  const total = passed + failed;
+  console.log(`  Results: ${passed}/${total} passed, ${failed} failed`);
+  console.log('='.repeat(70));
+
+  if (failed > 0) process.exit(1);
+}
+
+runTests().catch((e) => {
+  console.error('Test runner error:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR fixes four critical issues (#186–#189) in the dictionary lookup pipeline that caused incorrect definitions, missing grammar words, and inconsistent results across different API endpoints.

## Key Changes

### 1. Language Filtering (#186)
- **Problem**: Non-English JMDict glosses (German, Spanish, etc.) were leaking through as primary definitions
- **Fix**: Added `getEnglishGlosses()` helper that explicitly filters glosses by `lang === "en"` before returning them
- **Impact**: Words like 猫 no longer return German "Katze" when English "cat" is available

### 2. Sense Ordering (#187)
- **Problem**: Slang, archaic, and rare senses were scoring identically to everyday meanings because the code only scanned gloss text, never reading JMDict's structured `misc` array
- **Fix**: Implemented `getSenseCommonness()` that:
  - Penalizes senses with `misc: ['sl']` (slang), `['arch']` (archaic), `['obs']` (obsolete), `['rare']`, `['vulg']` (vulgar), `['X']` (rude), `['id']` (idiomatic)
  - Penalizes domain-restricted senses (`field` array)
  - Rewards senses with multiple English synonyms (indicator of well-established meanings)
- **Impact**: 猫 now returns "cat" instead of "submissive partner"; 桜 returns "cherry blossom" instead of "hired applauder"; 可愛い returns "cute/adorable" instead of "dainty"

### 3. Kana-Only Word Lookup (#188)
- **Problem**: Grammar words (です, ます, ない, etc.) were only looked up in kanji-data, never in JMDict, causing "Unknown meaning" on word detail pages while vocab cards showed correct definitions
- **Fix**: 
  - Unified all three lookup paths (`processText`, `processTextWithTokens`, `processStoryText`) through a single `resolveWordMeaning()` function
  - This function now calls JMDict for ALL words (not just kana-only), with proper fallback to kanji-data
  - Uses a shared lookup cache to avoid redundant dictionary queries
- **Impact**: Grammar words now consistently return correct definitions across all endpoints

### 4. Tokenizer Base Form Handling (#189)
- **Problem**: Conjugated verb forms weren't being looked up by their dictionary/citation form
- **Fix**: `resolveWordMeaning()` tries `baseForm` first (the citation form from tokenizer), then falls back to surface form
- **Impact**: Conjugated verbs like 寝ています are correctly resolved to their base form 寝る for dictionary lookup

### 5. JMDict Lookup Accuracy
- Switched from partial-match indexes (`readingAnywhere`/`kanjiAnywhere`) to exact-form prefix indexes (`readingBeginning`/`kanjiBeginning`)
- Filters results to exact matches only, eliminating false positives where substring matches (e.g., 'いい' matching おおきい) could return wrong entries
- Removed artificial 10-result limit that could miss the target entry

## Testing

Added comprehensive test suites:
- **`tests/test-dictionary-quality.ts`**: Integration tests against real JMDict data covering all four issues
- **`tests/test-server-api.ts`**: End-to-end API tests verifying the fixes work through the full server pipeline
- **`src/lib/dictionary.test.ts`**: Unit tests for `getEnglishGlosses()` and `getSenseCommonness()` helper functions

Updated morpheme definitions to include common grammar words (です, ない, etc.) with proper English descriptions.

## Implementation Details

- `resolveWordMeaning()` is the new single source of truth for word resolution, called by all three text processing functions
- Lookup cache is passed through the call chain to avoid redundant dictionary queries within a single request
- JMDict results are only used when they return a non-"Unknown" English definition, preserving kanji-data's accurate reading

https://claude.ai/code/session_01JnvAxg9a1hNivVSPeD1XH1