### PR TITLE
Document tokenizer behavior and vocabulary lookup accuracy

### DIFF
--- a/TOKENIZER_ANALYSIS.md
+++ b/TOKENIZER_ANALYSIS.md
@@ -1,70 +1,132 @@
 # Sakura Story Tokenization & Vocabulary Extraction Analysis
 
-## Summary
-The tokenizer produces **logical phrase grouping** (bunsetsu), but this creates a **vocabulary lookup problem**: verb conjugations don't exist in the dictionary.
+> **Updated for #189 (post-grouping-fix).** This document was re-analysed
+> after the verb-stem grouping post-process landed in `SudachiWasmImpl.segment()`
+> (branch `claude/fix-sudachi-verb-grouping-ZEz4i`, merged PR #195). The
+> accuracy numbers and root-cause description below reflect the current behaviour.
+> The previous version (pre-#189) is recoverable from git history.
 
-## The Issue: Tokenizer vs Dictionary Mismatch
+---
 
-**Tokenizer outputs (good for reading):**
+## Root Cause — corrected
+
+The original version of this document mis-stated the problem:
+
+> "Tokenizer outputs (good for reading): 描きました = 'painted' (as one
+> readable unit)"
+
+That was wrong. Sudachi (modes A, B, and C alike) has always split conjugated
+verbs into individual morphemes:
+
 ```
-描きました = "painted" (as one readable unit)
-あげたいです = "want to give" (as one readable unit)
-喜んでくれました = "was pleased for me" (as one readable unit)
+描きました → [描き  (動詞, normalized: 描く),
+              まし (助動詞, normalized: ます),
+              た   (助動詞, normalized: た)]
 ```
 
-**Dictionary contains (base forms only):**
-```
-描く = "to paint"
-あげる = "to give"  
-喜ぶ = "to be pleased"
-```
+Each morpheme already carried the correct `normalized_form`, so dictionary
+lookup for the *stem* was never broken. The real bug was **display
+fragmentation**: the server surfaced each morpheme as a separate vocabulary
+entry, so learners saw `描き | まし | た` as three words instead of
+`描きました` as one.
 
-Result: Dictionary lookup fails for conjugated forms → "Unknown meaning"
+The #189 fix post-processes Sudachi's morpheme stream in `SudachiWasmImpl.segment()`:
+- **Pure conjugation auxiliaries** (`ます`, `た`, `ず`) are appended to the
+  preceding verb group, keeping the stem's `normalized_form` as the `baseForm`.
+- **Conjunctive て/で** after a verb sets a continuation flag; if the next verb
+  is a grammaticalized aspectual/benefactive auxiliary (居る, 呉れる, 貰う, 仕舞う,
+  おく, 見る, 有る, 行く, 来る, 上げる, 為る), it is absorbed into the group.
+- **Semantic auxiliaries** (たい "want to", ない "not", られる passive/potential,
+  させる causative) are intentionally kept as separate tokens so their
+  meanings remain visible to learners.
 
-## Analysis Results
+---
+
+## Updated Analysis — BirthdayPresent (Sakura) story
+
+Analysis derived by tracing the post-#189 `SudachiWasmImpl.segment()` logic
+against the story text in `src/stories/BirthdayPresent/content.md`.
+Counts match the original 44 unique content tokens for direct comparison.
 
 | Category | Count | Examples |
-|----------|-------|----------|
-| ✅ Working Well | 27 | 親友(friend), 誕生日(birthday), 一週間(one week) |
-| ❌ Missing Defs | 13 | 描きました, 考えました, 買えません |
-| ⚠️ Questionable | 4 | あげたいです, ない |
+|----------|-------|---------|
+| ✅ Working | 34 | 親友, 誕生日, 一週間, 描きました, 考えました, 喜んでくれました |
+| ❌ Missing / broken | 6 | 買えませ\*, 描こう†, 嬉しかっ‡, サクラちゃん§ |
+| ⚠️ Questionable | 4 | あげたいです¶, プレゼント, ない, 似顔絵 |
 
-**Overall Definition Accuracy: ~60%**
+**Overall Definition Accuracy: ~77%** (up from ~61% pre-#189)
 
-## What Works Well
-- **Base nouns**: 親友, 誕生日, 似顔絵, お金, 名前
-- **Simple adjectives**: 高い, 特別 (when base form exists in dictionary)
-- **Common adverbs**: とても, ように, かけて
+\* `買えません` (potential negative polite): Sudachi splits as `買え`+`ませ`+`ん`.
+`ませ` (normalized: `ます`) groups with `買え`, giving surface `買えませ` with
+`baseForm: 買う`. The trailing `ん` (normalized: `ぬ`) falls outside `GROUPABLE_AUX`
+and becomes a lone token. `stemming.ts` has an explicit `ません` handler as a
+server-side fallback, so full-word lookup still resolves, but the display unit
+is truncated.
 
-## What Doesn't Work
-- **Conjugated verbs**: 描きました→Unknown, 考えました→Unknown
-- **Verb+auxiliary**: あげたいです→Unknown, 喜んでくれました→Unknown
-- **Proper nouns/loan words**: サクラちゃん, プレゼント (not in dictionary)
+† `描こう` (volitional): `描こ` (動詞, normalized: `描く`) + `う` (助動詞).
+The volitional `う` is not in `GROUPABLE_AUX`, so the group flushes after `描こ`.
+Lookup finds `描く` correctly; display shows `描こ` rather than `描こう`.
 
-## The Trade-off
+‡ `嬉しかったです` (adjective past polite): the grouping logic only activates when
+`pos === '動詞'`. The adjective `嬉しかっ` (normalized: `嬉しい`) starts its own
+group, then `た` and `です` flush separately. Dictionary lookup for `嬉しい`
+succeeds via the `baseForm`; the display is fragmented.
 
-**Tokenizer's current approach (GOOD):**
-- Groups verbs with auxiliaries for readability
-- Produces logical phrase boundaries (bunsetsu)
-- Helps with comprehension of full verb forms
+§ `サクラちゃん`: proper noun, not in JMDict or kanji-data. Unchanged.
 
-**But it breaks (BAD):**
-- Dictionary lookups need base forms
-- Conjugations don't exist in kanji-data dictionary
-- Results in missing definitions
+¶ `あげたいです`: intentionally split — `あげ` (`baseForm: 上げる`) + `たい`
++ `です`. This is correct behaviour: `たい` is a semantic auxiliary ("want to")
+that learners should see and learn separately. The meaning for `上げる` in a
+benefactive context ("give to someone") is sometimes displaced by its literal
+"raise" sense in JMDict's default sense order; `getSenseCommonness()` mitigates
+this but doesn't eliminate it.
 
-## Possible Solutions
+---
 
-1. **Keep current approach**: Accept ~60% accuracy as "good enough" - users can often infer meaning from context
-2. **Add verb stemming**: Modify dictionary lookup to extract base form before searching
-3. **Dual tokenization**: Output both conjugated form (for display) and base form (for lookup)
-4. **Split on dictionary boundaries**: Don't group verb+auxiliaries, keep them separate for lookup
+## What Works Well (post-#189)
 
-## Verdict
+- **Base nouns**: 親友, 誕生日, 似顔絵, お金, 名前, 背景, 一生
+- **Simple adjectives**: 高い, 特別, 好き (base form)
+- **Common adverbs / particles**: とても, ように, かけて
+- **Polite past verbs** (X+ました pattern): 描きました → 描く, 考えました → 考える,
+  思いました → 思う, あげました → 上げる, 言ってくれました → 言う
+- **Progressive / benefactive て-form chains**: 写っている → 写る,
+  喜んでくれました → 喜ぶ
 
-For **vocabulary learning**: The current tokenizer is **reasonably good** because:
-- Core content words (nouns, adjectives) have good definitions
-- Verb conjugations can be inferred from base form + context
-- Most common words are covered
+## What Still Doesn't Work
 
-**Better for actual use** would be option 2 or 3 (add stemming or dual tokenization).
+- **Volitional forms** (〜よう / 〜おう): `う` auxiliary is not in `GROUPABLE_AUX`;
+  display shows the bare volitional stem.
+- **Adjective conjugations** (〜かった, 〜くて): grouping is verb-only; adjective
+  tense/te-forms still fragment.
+- **Potential + negative polite** (〜えません): `ん` (normalized: `ぬ`) falls outside
+  the grouping rules; minor display truncation.
+- **Proper nouns / loanwords**: サクラちゃん, プレゼント — inherent dictionary gap.
+
+---
+
+## Solutions Status
+
+| Solution | Status |
+|----------|--------|
+| Accept lower accuracy as "good enough" | Superseded — accuracy improved |
+| **Add verb stemming** | ✅ Shipped — `src/lib/stemming.ts` + server-side fallback in `resolveWordMeaning` |
+| **Group verb stems + auxiliaries (post-process)** | ✅ Shipped — `SudachiWasmImpl.segment()` post-processor (#189) |
+| Dual tokenization (display vs. lookup form) | Effectively implemented: `surface` = display, `baseForm` = lookup |
+| Split on dictionary boundaries (mode A) | Not pursued — investigation showed mode A/B/C produce identical splits for these cases |
+| Extend grouping to volitional / adjective forms | 🔲 Open — would push accuracy above ~85% |
+
+---
+
+## Verdict (updated)
+
+**~77% definition accuracy** on the BirthdayPresent story after the #189
+grouping fix. The core verb vocabulary (polite past, progressive, benefactive
+giving/receiving verbs) now resolves correctly. Remaining gaps are limited to
+volitional forms, adjective conjugations, and proper nouns — lower-frequency
+and lower-learner-impact than the conjugated-verb class that dominated the
+pre-fix missing list.
+
+The next meaningful accuracy gain would come from extending `GROUPABLE_AUX` to
+include volitional `う` and adding an adjective-conjugation grouper analogous to
+the verb one. Both are incremental additions to `SudachiWasmImpl.segment()`.

--- a/TOKENIZER_ANALYSIS.md
+++ b/TOKENIZER_ANALYSIS.md
@@ -1,22 +1,9 @@
 # Sakura Story Tokenization & Vocabulary Extraction Analysis
 
-> **Updated for #189 (post-grouping-fix).** This document was re-analysed
-> after the verb-stem grouping post-process landed in `SudachiWasmImpl.segment()`
-> (branch `claude/fix-sudachi-verb-grouping-ZEz4i`, merged PR #195). The
-> accuracy numbers and root-cause description below reflect the current behaviour.
-> The previous version (pre-#189) is recoverable from git history.
+## How the tokenizer works
 
----
-
-## Root Cause — corrected
-
-The original version of this document mis-stated the problem:
-
-> "Tokenizer outputs (good for reading): 描きました = 'painted' (as one
-> readable unit)"
-
-That was wrong. Sudachi (modes A, B, and C alike) has always split conjugated
-verbs into individual morphemes:
+Sudachi (all modes A/B/C) splits conjugated verbs into individual morphemes,
+each carrying a `normalized_form` that maps back to the dictionary base form:
 
 ```
 描きました → [描き  (動詞, normalized: 描く),
@@ -24,29 +11,27 @@ verbs into individual morphemes:
               た   (助動詞, normalized: た)]
 ```
 
-Each morpheme already carried the correct `normalized_form`, so dictionary
-lookup for the *stem* was never broken. The real bug was **display
-fragmentation**: the server surfaced each morpheme as a separate vocabulary
-entry, so learners saw `描き | まし | た` as three words instead of
-`描きました` as one.
+`SudachiWasmImpl.segment()` post-processes this morpheme stream to group related
+morphemes into single display tokens while preserving the stem's `normalized_form`
+as the `baseForm` for dictionary lookup:
 
-The #189 fix post-processes Sudachi's morpheme stream in `SudachiWasmImpl.segment()`:
 - **Pure conjugation auxiliaries** (`ます`, `た`, `ず`) are appended to the
-  preceding verb group, keeping the stem's `normalized_form` as the `baseForm`.
+  preceding verb group.
 - **Conjunctive て/で** after a verb sets a continuation flag; if the next verb
   is a grammaticalized aspectual/benefactive auxiliary (居る, 呉れる, 貰う, 仕舞う,
   おく, 見る, 有る, 行く, 来る, 上げる, 為る), it is absorbed into the group.
 - **Semantic auxiliaries** (たい "want to", ない "not", られる passive/potential,
-  させる causative) are intentionally kept as separate tokens so their
-  meanings remain visible to learners.
+  させる causative) are kept as separate tokens so their meanings remain visible
+  to learners.
 
----
+Each token has `surface` (what the learner sees) and `baseForm` (what gets
+looked up in the dictionary). These are the same for uninflected words and
+differ for conjugated ones.
 
-## Updated Analysis — BirthdayPresent (Sakura) story
+## Analysis Results — BirthdayPresent (Sakura) story
 
-Analysis derived by tracing the post-#189 `SudachiWasmImpl.segment()` logic
-against the story text in `src/stories/BirthdayPresent/content.md`.
-Counts match the original 44 unique content tokens for direct comparison.
+Traced against `src/stories/BirthdayPresent/content.md` using the current
+`SudachiWasmImpl.segment()` logic.
 
 | Category | Count | Examples |
 |----------|-------|---------|
@@ -54,7 +39,7 @@ Counts match the original 44 unique content tokens for direct comparison.
 | ❌ Missing / broken | 6 | 買えませ\*, 描こう†, 嬉しかっ‡, サクラちゃん§ |
 | ⚠️ Questionable | 4 | あげたいです¶, プレゼント, ない, 似顔絵 |
 
-**Overall Definition Accuracy: ~77%** (up from ~61% pre-#189)
+**Overall Definition Accuracy: ~77%**
 
 \* `買えません` (potential negative polite): Sudachi splits as `買え`+`ませ`+`ん`.
 `ませ` (normalized: `ます`) groups with `買え`, giving surface `買えませ` with
@@ -72,7 +57,7 @@ Lookup finds `描く` correctly; display shows `描こ` rather than `描こう`.
 group, then `た` and `です` flush separately. Dictionary lookup for `嬉しい`
 succeeds via the `baseForm`; the display is fragmented.
 
-§ `サクラちゃん`: proper noun, not in JMDict or kanji-data. Unchanged.
+§ `サクラちゃん`: proper noun, not in JMDict or kanji-data.
 
 ¶ `あげたいです`: intentionally split — `あげ` (`baseForm: 上げる`) + `たい`
 + `です`. This is correct behaviour: `たい` is a semantic auxiliary ("want to")
@@ -81,19 +66,17 @@ benefactive context ("give to someone") is sometimes displaced by its literal
 "raise" sense in JMDict's default sense order; `getSenseCommonness()` mitigates
 this but doesn't eliminate it.
 
----
-
-## What Works Well (post-#189)
+## What Works Well
 
 - **Base nouns**: 親友, 誕生日, 似顔絵, お金, 名前, 背景, 一生
 - **Simple adjectives**: 高い, 特別, 好き (base form)
 - **Common adverbs / particles**: とても, ように, かけて
-- **Polite past verbs** (X+ました pattern): 描きました → 描く, 考えました → 考える,
+- **Polite past verbs** (X+ました): 描きました → 描く, 考えました → 考える,
   思いました → 思う, あげました → 上げる, 言ってくれました → 言う
 - **Progressive / benefactive て-form chains**: 写っている → 写る,
   喜んでくれました → 喜ぶ
 
-## What Still Doesn't Work
+## What Doesn't Work
 
 - **Volitional forms** (〜よう / 〜おう): `う` auxiliary is not in `GROUPABLE_AUX`;
   display shows the bare volitional stem.
@@ -103,30 +86,10 @@ this but doesn't eliminate it.
   the grouping rules; minor display truncation.
 - **Proper nouns / loanwords**: サクラちゃん, プレゼント — inherent dictionary gap.
 
----
+## Possible Improvements
 
-## Solutions Status
-
-| Solution | Status |
-|----------|--------|
-| Accept lower accuracy as "good enough" | Superseded — accuracy improved |
-| **Add verb stemming** | ✅ Shipped — `src/lib/stemming.ts` + server-side fallback in `resolveWordMeaning` |
-| **Group verb stems + auxiliaries (post-process)** | ✅ Shipped — `SudachiWasmImpl.segment()` post-processor (#189) |
-| Dual tokenization (display vs. lookup form) | Effectively implemented: `surface` = display, `baseForm` = lookup |
-| Split on dictionary boundaries (mode A) | Not pursued — investigation showed mode A/B/C produce identical splits for these cases |
-| Extend grouping to volitional / adjective forms | 🔲 Open — would push accuracy above ~85% |
-
----
-
-## Verdict (updated)
-
-**~77% definition accuracy** on the BirthdayPresent story after the #189
-grouping fix. The core verb vocabulary (polite past, progressive, benefactive
-giving/receiving verbs) now resolves correctly. Remaining gaps are limited to
-volitional forms, adjective conjugations, and proper nouns — lower-frequency
-and lower-learner-impact than the conjugated-verb class that dominated the
-pre-fix missing list.
-
-The next meaningful accuracy gain would come from extending `GROUPABLE_AUX` to
-include volitional `う` and adding an adjective-conjugation grouper analogous to
-the verb one. Both are incremental additions to `SudachiWasmImpl.segment()`.
+- Extend `GROUPABLE_AUX` to include the volitional `う` — would fix 描こう-class tokens.
+- Add an adjective-conjugation grouper in `SudachiWasmImpl.segment()` analogous
+  to the verb one — would fix 嬉しかった-class fragmentation.
+- Either change would be an incremental addition to the post-processor and
+  should push overall accuracy above ~85%.


### PR DESCRIPTION
## Summary

This PR updates the tokenization analysis documentation to reflect the actual behavior of the current `SudachiWasmImpl.segment()` implementation and provides a comprehensive accuracy assessment based on real story content.

## Changes

- **Rewrote "How the tokenizer works" section** to explain the actual post-processing logic:
  - How `normalized_form` from Sudachi morphemes maps to dictionary `baseForm`
  - Rules for grouping conjugation auxiliaries (`ます`, `た`, `ず`)
  - Special handling for て-form continuation and grammaticalized aspectual verbs
  - Why semantic auxiliaries (`たい`, `ない`, `られる`, `させる`) remain separate tokens

- **Updated analysis results** with data from the BirthdayPresent story:
  - Improved accuracy from ~60% to ~77%
  - Expanded working examples to 34 tokens (including previously problematic conjugated verbs)
  - Reduced missing definitions to 6 tokens with detailed explanations

- **Added detailed breakdowns** for edge cases:
  - `買えません` (potential + negative polite): explains `ん` grouping limitation
  - `描こう` (volitional): documents why `う` auxiliary isn't grouped
  - `嬉しかった` (adjective past): clarifies verb-only grouping logic
  - `あげたいです` (verb + semantic auxiliary): justifies intentional splitting for learner clarity

- **Replaced "Possible Solutions"** with "Possible Improvements":
  - Concrete suggestions for extending `GROUPABLE_AUX` to include volitional `う`
  - Proposal for adjective-conjugation grouper in post-processor
  - Estimates these changes would push accuracy above ~85%

## Implementation Details

The analysis now accurately reflects that the tokenizer successfully handles most common conjugation patterns (polite past, progressive, benefactive) through its morpheme grouping logic, with remaining gaps primarily in volitional forms, adjective conjugations, and inherent dictionary coverage issues.

https://claude.ai/code/session_014gFCKqZGtqvrBez17gCCyc