### PR TITLE
Move startup extraction to worker thread (fix #200)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1029,11 +1029,13 @@ async function startServer() {
         jishoCacheEntries: jishoCache.entries(),
       };
 
-      const workerUrl = new URL('./src/lib/extraction-worker.ts', import.meta.url);
-      const worker = new Worker(workerUrl, {
-        execArgv: process.execArgv, // inherit tsx loader so .ts imports work
-        workerData,
-      });
+      // Use the plain-JS shim as the worker entry point.
+      // The shim calls register() with the tsx ESM loader so that .ts imports
+      // work inside the worker thread before bootstrapping extraction-worker.ts.
+      // Pointing at the .ts file directly and passing execArgv=['--import','tsx/esm']
+      // does not work: tsx skips hook registration when isMainThread is false.
+      const workerUrl = new URL('./src/lib/extraction-worker-shim.mjs', import.meta.url);
+      const worker = new Worker(workerUrl, { workerData });
 
       let currentChunk = 0;
 

--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,8 @@ import { ensureJmnedictPrepared } from "./src/lib/jmnedict-utils.js";
 import { getMorphemeDefinition } from "./src/lib/morphemeDefinitions.js";
 import { loadStoriesFromDisk, loadMusicFromDisk, loadVideosFromDisk } from "./src/lib/storyLoader.js";
 import { initDatabase, WordsCache, JishoCache, ContentWordsStore, saveDatabase } from "./src/lib/database.js";
+import { isPunctuation, isSingleKana } from "./src/lib/extraction-helpers.js";
+import type { WorkerInitData, WorkerOutMessage } from "./src/lib/extraction-worker.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -276,10 +278,6 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
   const tokens = await tokenizer.segment(text);
 
-  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
-  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
-  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
-
   // Count how many times each word appears (for frequencyInContent)
   const baseFormCounts = new Map<string, number>();
   const validWords = new Map<string, string>(); // Map surface form to baseForm for lookup
@@ -369,9 +367,6 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
 }
 
 async function processTextWithTokens(text: string, tokens: any[], kanaLookupCache: Map<string, any>) {
-  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
-  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
-  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
 
   // Count how many times each word appears (for frequencyInContent)
   const baseFormCounts = new Map<string, number>();
@@ -463,10 +458,6 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
 async function processStoryText(text: string) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
   const tokenInfos = await tokenizer.segment(text);
-
-  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
-  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
-  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
 
   // Find positions of each segment in the original text
   const tokens: any[] = [];
@@ -573,10 +564,6 @@ async function runBatchExtract(texts: { id: string; text: string }[]): Promise<B
   console.log(`[API] /api/batch-extract: Step 1 - Tokenization completed in ${Date.now() - tokenStart}ms`);
 
   // Collect unique kana-only words from all texts
-  const particles = new Set(["は", "が", "を", "に", "へ", "と", "で", "も", "か", "の", "て", "な", "だ"]);
-  const isPunctuation = (s: string) => /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
-  const isSingleKana = (s: string) => s.length === 1 && (particles.has(s) || /[ぁ-ん]/.test(s));
-
   const collectStart = Date.now();
   const uniqueKanaWords = new Set<string>();
   for (const item of tokenizedBatch) {
@@ -1003,7 +990,10 @@ async function startServer() {
     console.log(`Server running on http://localhost:${PORT}`);
   });
 
-  // Kick off background extraction for any content not yet in content_words
+  // Kick off background extraction for any content not yet in content_words.
+  // Runs in a worker_threads Worker so the Express event loop stays responsive
+  // to user-facing API requests during the potentially minutes-long warmup.
+  // Fix for #200: previously this ran inline and blocked the event loop.
   (async () => {
     try {
       const allContent = [
@@ -1016,15 +1006,74 @@ async function startServer() {
         console.log('[Server] All content already extracted — skipping startup extraction');
         return;
       }
-      console.log(`[Server] Starting background extraction for ${missing.length}/${allContent.length} content items`);
+      console.log(`[Server] Starting background extraction for ${missing.length}/${allContent.length} content items (worker thread)`);
+
+      const { Worker } = await import('worker_threads');
+
+      // Build chunks upfront; we send one chunk at a time (wait for 'done' before
+      // sending the next) so the worker's event loop isn't flooded.
       const CHUNK_SIZE = 20;
+      const chunks: Array<{ id: string; text: string }[]> = [];
       for (let i = 0; i < missing.length; i += CHUNK_SIZE) {
-        const chunk = missing.slice(i, i + CHUNK_SIZE).map(c => ({ id: c.id, text: c.text }));
-        await runBatchExtract(chunk);
+        chunks.push(missing.slice(i, i + CHUNK_SIZE).map(c => ({ id: c.id, text: c.text })));
       }
-      console.log(`[Server] Startup extraction complete`);
+
+      const workerData: WorkerInitData = {
+        jmdictPath: path.join(__dirname, 'jmdict-db'),
+        jmdictFile: fs.existsSync(path.join(__dirname, 'jmdict-all-3.6.2.json'))
+          ? path.join(__dirname, 'jmdict-all-3.6.2.json')
+          : null,
+        jmnedictFile,
+        // Seed the worker's kana cache with everything already persisted in this
+        // process so the worker avoids redundant Jisho API round-trips.
+        jishoCacheEntries: jishoCache.entries(),
+      };
+
+      const workerUrl = new URL('./src/lib/extraction-worker.ts', import.meta.url);
+      const worker = new Worker(workerUrl, {
+        execArgv: process.execArgv, // inherit tsx loader so .ts imports work
+        workerData,
+      });
+
+      let currentChunk = 0;
+
+      const sendNextChunk = () => {
+        if (currentChunk < chunks.length) {
+          worker.postMessage({ type: 'extract', items: chunks[currentChunk] });
+        } else {
+          console.log('[Server] Startup extraction complete');
+          worker.terminate();
+        }
+      };
+
+      worker.on('message', (msg: WorkerOutMessage) => {
+        switch (msg.type) {
+          case 'ready':
+            console.log('[Server] Extraction worker ready');
+            sendNextChunk();
+            break;
+          case 'result':
+            if (msg.words && Array.isArray(msg.words)) {
+              contentWordsStore.setContentWords(msg.id, msg.words);
+            }
+            break;
+          case 'done':
+            saveDatabase();
+            currentChunk++;
+            console.log(`[Server] Extraction progress: ${currentChunk}/${chunks.length} chunks`);
+            sendNextChunk();
+            break;
+          case 'init_error':
+            console.error('[Server] Extraction worker error:', msg.message);
+            break;
+        }
+      });
+
+      worker.on('error', e =>
+        console.error('[Server] Extraction worker thread error:', e instanceof Error ? e.message : String(e)),
+      );
     } catch (e) {
-      console.error('[Server] Startup extraction error:', e instanceof Error ? e.message : String(e));
+      console.error('[Server] Failed to start extraction worker:', e instanceof Error ? e.message : String(e));
     }
   })();
 

--- a/src/lib/extraction-helpers.test.ts
+++ b/src/lib/extraction-helpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord } from './extraction-helpers.js';
+
+describe('extraction helpers', () => {
+  describe('isPunctuation', () => {
+    it('returns true for Japanese punctuation characters', () => {
+      for (const ch of ['。', '、', '！', '？', '・', '「', '」', '『', '』', '（', '）']) {
+        expect(isPunctuation(ch), `expected isPunctuation('${ch}') to be true`).toBe(true);
+      }
+    });
+
+    it('returns true for ASCII alphanumerics and whitespace', () => {
+      expect(isPunctuation('a')).toBe(true);
+      expect(isPunctuation('Z')).toBe(true);
+      expect(isPunctuation('0')).toBe(true);
+      expect(isPunctuation(' ')).toBe(true);
+    });
+
+    it('returns false for kanji', () => {
+      expect(isPunctuation('猫')).toBe(false);
+      expect(isPunctuation('食')).toBe(false);
+    });
+
+    it('returns false for hiragana words', () => {
+      expect(isPunctuation('ねこ')).toBe(false);
+      expect(isPunctuation('は')).toBe(false);
+    });
+  });
+
+  describe('isSingleKana', () => {
+    it('returns true for standard particles', () => {
+      for (const p of ['は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ']) {
+        expect(isSingleKana(p), `expected isSingleKana('${p}') to be true`).toBe(true);
+      }
+    });
+
+    it('returns true for single hiragana non-particles', () => {
+      expect(isSingleKana('あ')).toBe(true);
+      expect(isSingleKana('い')).toBe(true);
+      expect(isSingleKana('う')).toBe(true);
+    });
+
+    it('returns false for multi-character strings', () => {
+      expect(isSingleKana('ねこ')).toBe(false);
+      expect(isSingleKana('は　')).toBe(false);
+    });
+
+    it('returns false for single kanji', () => {
+      expect(isSingleKana('猫')).toBe(false);
+      expect(isSingleKana('日')).toBe(false);
+    });
+
+    it('returns false for katakana', () => {
+      expect(isSingleKana('ア')).toBe(false);
+    });
+  });
+
+  describe('isHiraganaWord', () => {
+    it('returns true for pure hiragana strings', () => {
+      expect(isHiraganaWord('ありがとう')).toBe(true);
+      expect(isHiraganaWord('ねこ')).toBe(true);
+      expect(isHiraganaWord('です')).toBe(true);
+      expect(isHiraganaWord('は')).toBe(true);
+    });
+
+    it('returns false for mixed strings with kanji', () => {
+      expect(isHiraganaWord('食べる')).toBe(false);
+      expect(isHiraganaWord('猫は')).toBe(false);
+    });
+
+    it('returns false for katakana', () => {
+      expect(isHiraganaWord('テスト')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isHiraganaWord('')).toBe(false);
+    });
+  });
+
+  describe('isKatakanaWord', () => {
+    it('returns true for pure katakana including long-vowel mark', () => {
+      expect(isKatakanaWord('テスト')).toBe(true);
+      expect(isKatakanaWord('コーヒー')).toBe(true);
+      expect(isKatakanaWord('ヴァイオリン')).toBe(true);
+    });
+
+    it('returns false for hiragana', () => {
+      expect(isKatakanaWord('ねこ')).toBe(false);
+    });
+
+    it('returns false for mixed kanji-katakana', () => {
+      expect(isKatakanaWord('日テレ')).toBe(false);
+    });
+  });
+
+  describe('PARTICLES', () => {
+    it('contains the standard set of Japanese particles', () => {
+      for (const p of ['は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ']) {
+        expect(PARTICLES.has(p), `PARTICLES should contain '${p}'`).toBe(true);
+      }
+    });
+
+    it('does not contain kanji or non-particle strings', () => {
+      expect(PARTICLES.has('猫')).toBe(false);
+      expect(PARTICLES.has('ありがとう')).toBe(false);
+    });
+  });
+});

--- a/src/lib/extraction-helpers.ts
+++ b/src/lib/extraction-helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure token-filter helpers shared between server.ts (inline extraction) and
+ * extraction-worker.ts (worker-thread startup extraction).
+ *
+ * Previously duplicated verbatim across processText, processTextWithTokens, and
+ * runBatchExtract.  Centralised here so both code paths stay in sync.
+ */
+
+export const PARTICLES = new Set([
+  'は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ',
+]);
+
+/** Returns true for characters that should be skipped entirely during extraction. */
+export function isPunctuation(s: string): boolean {
+  return /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+}
+
+/**
+ * Returns true for single-character tokens that are particles or plain hiragana.
+ * These are filtered out before dictionary lookup (they're grammatical glue, not
+ * vocabulary items worth showing to learners).
+ */
+export function isSingleKana(s: string): boolean {
+  return s.length === 1 && (PARTICLES.has(s) || /[ぁ-ん]/.test(s));
+}
+
+/** Returns true when the entire string is hiragana (small-kana inclusive). */
+export function isHiraganaWord(s: string): boolean {
+  return s.length > 0 && /^[ぁ-ん]+$/.test(s);
+}
+
+/** Returns true when the entire string is katakana (long-vowel mark inclusive). */
+export function isKatakanaWord(s: string): boolean {
+  return s.length > 0 && /^[ァ-ヴー]+$/.test(s);
+}

--- a/src/lib/extraction-worker-shim.mjs
+++ b/src/lib/extraction-worker-shim.mjs
@@ -1,0 +1,32 @@
+/**
+ * Plain-JS bootstrap shim for extraction-worker.ts (fix for #200).
+ *
+ * Worker threads cannot inherit the parent's tsx module hooks — tsx skips
+ * hook registration when isMainThread is false.  Passing --import tsx/esm in
+ * execArgv has the same problem: tsx's initialize() requires a truthy data
+ * argument that only arrives when Node itself invokes it via --import on the
+ * CLI, not when the module is loaded inside a worker.
+ *
+ * This shim:
+ *   1. Calls register() with the tsx ESM loader and { data: {} } so that tsx's
+ *      initialize() hook receives a truthy argument and wires up its resolve/load
+ *      hooks for this worker thread.
+ *   2. Dynamically imports extraction-worker.ts so all its .js-extension imports
+ *      resolve to the corresponding .ts source files via the now-active tsx hooks.
+ *
+ * server.ts spawns this shim as the Worker entry point instead of pointing
+ * directly at the .ts file.
+ */
+
+import { register } from 'node:module';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+
+const req = createRequire(import.meta.url);
+const tsxEsm = req.resolve('tsx/esm');
+
+// { data: {} } satisfies tsx's initialize() check (it throws if data is falsy)
+register(tsxEsm, pathToFileURL(process.cwd() + '/'), { data: {} });
+
+// With tsx hooks active, .ts files can now be imported from this worker thread.
+await import('./extraction-worker.ts');

--- a/src/lib/extraction-worker.ts
+++ b/src/lib/extraction-worker.ts
@@ -1,0 +1,358 @@
+/**
+ * Worker-thread script for startup batch extraction (fix for #200).
+ *
+ * The main thread (server.ts) spawns this worker when it detects content items
+ * missing from content_words.  All CPU/IO-heavy work (Sudachi tokenisation +
+ * dictionary lookups) runs here so the Express event loop stays responsive to
+ * user-facing API calls during the warmup period.
+ *
+ * Message protocol (all messages are plain serialisable objects):
+ *
+ *   Main → Worker
+ *     { type: 'extract', items: Array<{ id: string; text: string }> }
+ *
+ *   Worker → Main
+ *     { type: 'ready' }                          — sent once after init completes
+ *     { type: 'result', id, words?, elapsed?, error? }  — one per input item
+ *     { type: 'done', processed: number }        — sent after every batch
+ *     { type: 'init_error', message: string }    — fatal init failure
+ */
+
+import { workerData, parentPort, isMainThread } from 'worker_threads';
+import fs from 'fs';
+import { createTokenizer, Tokenizer } from './tokenizers.js';
+import { DictionaryManager } from './dictionary.js';
+import {
+  getCachedDictionaryEntries,
+  findBestVariant,
+  getWordScoreBreakdown,
+} from './scoring.js';
+import { getMorphemeDefinition } from './morphemeDefinitions.js';
+import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord } from './extraction-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Public types (imported by server.ts for type-safety on the message channel)
+// ---------------------------------------------------------------------------
+
+export interface WorkerInitData {
+  jmdictPath: string;
+  jmdictFile: string | null;
+  jmnedictFile: string | null;
+  /** Serialised entries from the main thread's JishoCache, to avoid re-fetching
+   *  lookups already in the persistent cache. */
+  jishoCacheEntries: [string, any][];
+}
+
+export type WorkerOutMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; words?: any[]; elapsed?: number; error?: string }
+  | { type: 'done'; processed: number }
+  | { type: 'init_error'; message: string };
+
+export type WorkerInMessage =
+  | { type: 'extract'; items: Array<{ id: string; text: string }> };
+
+// ---------------------------------------------------------------------------
+// Worker-local state (only populated when running in a worker thread)
+// ---------------------------------------------------------------------------
+
+let tokenizer: Tokenizer | null = null;
+let dictionary: DictionaryManager | null = null;
+
+// In-memory kana lookup cache, seeded from the main thread's persistent cache.
+// Avoids redundant Jisho HTTP calls for words already looked up previously.
+const kanaCache = new Map<string, any>();
+
+// ---------------------------------------------------------------------------
+// Extraction logic (mirrors runBatchExtract in server.ts minus DB writes)
+// ---------------------------------------------------------------------------
+
+async function resolveWordMeaning(
+  wordStr: string,
+  baseForm: string,
+  lookupCache: Map<string, any>,
+): Promise<{ reading: string; meaning: string; meanings: string[] | undefined }> {
+  if (/^[ぁ-んー]+$/.test(wordStr)) {
+    const morphemeDef = getMorphemeDefinition(wordStr);
+    if (morphemeDef) return { reading: wordStr, meaning: morphemeDef, meanings: undefined };
+  }
+
+  let entries = getCachedDictionaryEntries(baseForm);
+  if (entries.length === 0 && baseForm !== wordStr) {
+    entries = getCachedDictionaryEntries(wordStr);
+  }
+  const { variant, entry } = findBestVariant(baseForm, entries);
+
+  let reading = wordStr;
+  let kanjiMeaning = 'Unknown meaning';
+  let kanjiMeanings: string[] | undefined;
+
+  if (entry && variant) {
+    reading = variant.pronounced || wordStr;
+    kanjiMeaning = entry.meanings[0]?.glosses?.join(', ') || kanjiMeaning;
+    const allKanjiMeanings: string[] = [];
+    const seen = new Set<string>();
+    for (const m of entry.meanings) {
+      for (const g of (m.glosses || [])) {
+        if (!seen.has(g)) { seen.add(g); allKanjiMeanings.push(g); }
+      }
+    }
+    if (allKanjiMeanings.length > 1) kanjiMeanings = allKanjiMeanings;
+  }
+
+  let meaning = kanjiMeaning;
+  let meanings = kanjiMeanings;
+
+  if (dictionary) {
+    const cacheKey = baseForm !== wordStr ? baseForm : wordStr;
+    let dictResult: any = lookupCache.get(cacheKey) ?? null;
+
+    if (dictResult === null) {
+      dictResult = await dictionary.lookup(baseForm);
+      if (!dictResult && baseForm !== wordStr) {
+        dictResult = await dictionary.lookup(wordStr);
+      }
+      lookupCache.set(cacheKey, dictResult ?? false);
+    }
+
+    if (dictResult && dictResult !== false) {
+      const jmdictMeaning = dictResult.meaning;
+      if (jmdictMeaning && jmdictMeaning !== 'Unknown') {
+        if (!reading || reading === wordStr) reading = dictResult.reading || reading;
+        meaning = jmdictMeaning;
+        meanings = dictResult.meanings;
+      }
+    }
+  }
+
+  if (meaning === 'Unknown meaning' && /^[ぁ-ん]+$/.test(wordStr)) {
+    const morphemeFallback = getMorphemeDefinition(wordStr);
+    meaning = morphemeFallback || 'Kana particle / expression';
+  }
+
+  return { reading, meaning, meanings };
+}
+
+async function processTokens(
+  tokens: any[],
+  wordStr_baseFormMap: Map<string, string>,
+  kanaLookupCache: Map<string, any>,
+): Promise<any[]> {
+  const baseFormCounts = new Map<string, number>();
+  const validWords = new Map<string, string>();
+  const morphemes = new Map<string, number>();
+
+  for (const token of tokens) {
+    const surface = token.surface;
+    if (surface.trim() === '' || isPunctuation(surface)) continue;
+
+    const morphemeDef = getMorphemeDefinition(surface);
+    const isKanaMorpheme = morphemeDef && /^[ぁ-んー]+$/.test(surface);
+    if (isSingleKana(surface) || isKanaMorpheme) {
+      if (morphemeDef) morphemes.set(surface, (morphemes.get(surface) ?? 0) + 1);
+    } else {
+      const baseForm = wordStr_baseFormMap.get(surface) ?? token.baseForm;
+      validWords.set(surface, baseForm);
+      baseFormCounts.set(surface, (baseFormCounts.get(surface) ?? 0) + 1);
+    }
+  }
+
+  const results: any[] = [];
+
+  for (const [wordStr, baseForm] of validWords) {
+    const { reading, meaning, meanings } = await resolveWordMeaning(wordStr, baseForm, kanaLookupCache);
+    const entries = getCachedDictionaryEntries(baseForm);
+    const { variant } = findBestVariant(baseForm, entries);
+    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
+    const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
+    const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
+    if (meanings) wordData.meanings = meanings;
+    results.push(wordData);
+  }
+
+  for (const [morpheme, frequency] of morphemes) {
+    const meaning = getMorphemeDefinition(morpheme) || 'Grammatical morpheme';
+    results.push({
+      word: morpheme,
+      reading: morpheme,
+      meaning,
+      jlpt: 0,
+      joyo: false,
+      score: 0,
+      breakdown: {
+        jlptScore: 0, joyoPenalty: 0, highestGrade: null,
+        freqPenalty: 0, jlptValues: [], gradeValues: [], priorities: [],
+      },
+      frequencyInContent: frequency,
+      isMorpheme: true,
+    });
+  }
+
+  return results;
+}
+
+type BatchItem = { id: string; text: string };
+type BatchResult = { id: string; words?: any[]; elapsed?: number; error?: string };
+
+async function extractBatch(items: BatchItem[]): Promise<BatchResult[]> {
+  if (!tokenizer) throw new Error('Tokenizer not initialised');
+
+  const sorted = [...items].sort((a, b) => (a.text?.length ?? 0) - (b.text?.length ?? 0));
+
+  // Step 1: tokenise all items concurrently
+  const tokenizedBatch = await Promise.all(
+    sorted.map(async (item) => {
+      if (!item.text || typeof item.text !== 'string') return { ...item, tokens: null };
+      try {
+        return { ...item, tokens: await tokenizer!.segment(item.text) };
+      } catch {
+        return { ...item, tokens: null };
+      }
+    }),
+  );
+
+  // Step 2: collect unique kana words across the whole batch
+  const uniqueKanaWords = new Set<string>();
+  for (const item of tokenizedBatch) {
+    if (!item.tokens) continue;
+    for (const token of item.tokens) {
+      const s = token.surface;
+      if (s.trim() === '' || isPunctuation(s) || isSingleKana(s)) continue;
+      if (isHiraganaWord(s) || isKatakanaWord(s)) uniqueKanaWords.add(s);
+    }
+  }
+
+  // Step 3: look up kana words with a concurrency cap; seed from warm cache
+  const kanaLookupCache = new Map<string, any>(
+    Array.from(kanaCache.entries()).filter(([k]) => uniqueKanaWords.has(k)),
+  );
+
+  if (dictionary && uniqueKanaWords.size > 0) {
+    const uncached = Array.from(uniqueKanaWords).filter(w => !kanaLookupCache.has(w));
+    const CONCURRENCY = 5;
+    let active = 0;
+    let idx = 0;
+
+    await new Promise<void>((resolve, reject) => {
+      const next = async () => {
+        try {
+          if (idx >= uncached.length && active === 0) { resolve(); return; }
+          while (active < CONCURRENCY && idx < uncached.length) {
+            const word = uncached[idx++];
+            active++;
+            dictionary!.lookup(word)
+              .then(result => {
+                const val = result ?? false;
+                kanaLookupCache.set(word, val);
+                if (result) kanaCache.set(word, result);
+              })
+              .catch(() => { kanaLookupCache.set(word, false); })
+              .finally(() => { active--; next().catch(reject); });
+          }
+          if (idx >= uncached.length && active === 0) resolve();
+        } catch (err) { reject(err); }
+      };
+      next().catch(reject);
+    });
+  }
+
+  // Step 3.5: pre-populate kanji words from kanji-data (synchronous, fast)
+  const surfaceToBase = new Map<string, string>();
+  for (const item of tokenizedBatch) {
+    if (!item.tokens) continue;
+    for (const token of item.tokens) {
+      const s = token.surface;
+      if (s.trim() === '' || isPunctuation(s) || isSingleKana(s)) continue;
+      if (!isHiraganaWord(s) && !isKatakanaWord(s)) surfaceToBase.set(s, token.baseForm);
+    }
+  }
+
+  // Step 4: process each item using the pre-built lookup caches
+  const results: BatchResult[] = await Promise.all(
+    tokenizedBatch.map(async (item) => {
+      if (!item.text || !item.tokens) {
+        return { id: item.id, error: !item.text ? 'No text' : 'Tokenization failed' };
+      }
+      const start = Date.now();
+      try {
+        const words = await processTokens(item.tokens, surfaceToBase, kanaLookupCache);
+        return { id: item.id, words, elapsed: Date.now() - start };
+      } catch (e: any) {
+        return { id: item.id, error: e instanceof Error ? e.message : String(e) };
+      }
+    }),
+  );
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Worker initialisation and message loop
+// Only runs when this module is loaded inside a worker_threads Worker, not
+// when it is imported for its type exports in tests or other modules.
+// ---------------------------------------------------------------------------
+
+async function runWorker(data: WorkerInitData) {
+  // Seed the kana cache from entries the main thread already has persisted.
+  for (const [word, result] of data.jishoCacheEntries) {
+    kanaCache.set(word, result);
+  }
+
+  tokenizer = await createTokenizer();
+
+  const onJishoCacheUpdate = (cache: Map<string, any>) => {
+    for (const [k, v] of cache) kanaCache.set(k, v);
+  };
+
+  dictionary = new DictionaryManager();
+  if (data.jmdictFile && fs.existsSync(data.jmdictFile)) {
+    await dictionary.initialize(
+      'jmdict',
+      data.jmdictPath,
+      data.jmdictFile,
+      data.jmnedictFile ?? undefined,
+      kanaCache as any,
+      onJishoCacheUpdate,
+    );
+  } else {
+    await dictionary.initialize(
+      'jisho',
+      undefined,
+      undefined,
+      data.jmnedictFile ?? undefined,
+      kanaCache as any,
+      onJishoCacheUpdate,
+    );
+  }
+
+  parentPort!.postMessage({ type: 'ready' } satisfies WorkerOutMessage);
+
+  parentPort!.on('message', async (msg: WorkerInMessage) => {
+    if (msg.type !== 'extract') return;
+    let processed = 0;
+    try {
+      const results = await extractBatch(msg.items);
+      for (const result of results) {
+        parentPort!.postMessage({ type: 'result', ...result } satisfies WorkerOutMessage);
+        processed++;
+      }
+    } catch (e: any) {
+      parentPort!.postMessage({
+        type: 'init_error',
+        message: e instanceof Error ? e.message : String(e),
+      } satisfies WorkerOutMessage);
+    }
+    parentPort!.postMessage({ type: 'done', processed } satisfies WorkerOutMessage);
+  });
+}
+
+// Guard: only activate worker logic when actually running inside a Worker whose
+// workerData was supplied by our own spawn call (identified by the jmdictPath key).
+if (!isMainThread && workerData != null && typeof (workerData as any).jmdictPath === 'string') {
+  runWorker(workerData as WorkerInitData).catch(e => {
+    parentPort?.postMessage({
+      type: 'init_error',
+      message: e instanceof Error ? e.message : String(e),
+    } satisfies WorkerOutMessage);
+  });
+}


### PR DESCRIPTION
## Summary
Refactors the startup batch extraction process to run in a `worker_threads` Worker instead of blocking the main Express event loop. This fixes issue #200 where the server became unresponsive during the potentially minutes-long warmup period when extracting words from all content items.

## Key Changes

- **New `extraction-worker.ts` module**: Implements a worker thread that handles all CPU/IO-heavy work (Sudachi tokenization + dictionary lookups) independently. The worker:
  - Receives batches of content items via message passing
  - Processes tokens and resolves word meanings using cached lookups
  - Returns results back to the main thread without blocking the Express event loop
  - Seeds its kana cache from the main thread's persistent JishoCache to avoid redundant API calls

- **New `extraction-helpers.ts` module**: Centralizes token-filtering logic (`isPunctuation`, `isSingleKana`, `isHiraganaWord`, `isKatakanaWord`, and `PARTICLES` set) that was previously duplicated across three functions in `server.ts`. Both the main thread and worker thread now import from this shared module.

- **Updated `server.ts`**:
  - Removes duplicate helper function definitions from `processText`, `processTextWithTokens`, `processStoryText`, and `runBatchExtract`
  - Imports helpers from `extraction-helpers.ts`
  - Replaces inline `runBatchExtract` calls during startup with worker thread spawning
  - Implements message-passing protocol to send chunks sequentially and save results as they arrive
  - Maintains backward compatibility: inline extraction still works for API calls

- **New test file `extraction-helpers.test.ts`**: Comprehensive test coverage for all helper functions with edge cases (particles, kanji, hiragana, katakana, punctuation).

## Implementation Details

- Worker initialization is guarded by checking `workerData.jmdictPath` to ensure the module only activates worker logic when actually running inside a spawned Worker
- Chunks are sent sequentially (waiting for 'done' before sending the next) to prevent event loop flooding
- The worker's kana lookup cache is seeded from the main thread's persistent cache entries to minimize redundant Jisho API calls
- All message types are TypeScript-typed via `WorkerInMessage` and `WorkerOutMessage` for type safety

https://claude.ai/code/session_01LQGpdt13wPt58wKcN3PAju