### PR TITLE
Extract word resolution logic into WordResolver class

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -6,19 +6,9 @@ import fs from "fs";
 import * as tar from "tar";
 import zlib from "zlib";
 import {
-  DictionaryVariant,
-  DictionaryEntry,
-  FindBestVariantResult,
-  JLPT_SCORES,
-  JOYO_PENALTIES,
-  getFrequencyPenalty,
-  getWordScoreBreakdown,
   getCachedDictionaryEntries,
-  findBestVariant,
-  markCacheAsDirty,
-  shouldSaveCache,
-  clearCacheDirtyFlag,
 } from "./src/lib/scoring.js";
+import { WordResolver } from "./src/lib/wordResolver.js";
 import { DictionaryManager } from "./src/lib/dictionary.js";
 import { createTokenizer, Tokenizer } from "./src/lib/tokenizers.js";
 import { ensureJmnedictPrepared } from "./src/lib/jmnedict-utils.js";
@@ -66,6 +56,7 @@ async function ensureJmdictExtracted() {
 
 let tokenizer: Tokenizer | null = null;
 let dictionary: DictionaryManager | null = null;
+let wordResolver: WordResolver | null = null;
 
 const tokenizerReady = (async () => {
   try {
@@ -134,6 +125,7 @@ const dictionaryReady = (async () => {
     await dictionary.initialize('jisho', undefined, undefined, jmnedictFile as string | undefined, jishoCache as any, onJishoCacheUpdate);
   }
   console.log('[Dictionary] Initialization complete');
+  wordResolver = new WordResolver(dictionary);
 
   // Pre-load all cached words from database into memory for fast lookups
   const preloadStart = Date.now();
@@ -174,103 +166,6 @@ const dictionaryReady = (async () => {
 })();
 
 
-/**
- * Single source of truth for resolving a Japanese word's reading + meaning.
- *
- * Fix for #188: three separate code paths (processText, processStoryText, and
- * /api/word/:word) previously had slightly different lookup logic. The word
- * detail page only used getCachedDictionaryEntries (kanji-data) and never called
- * the dictionary for kana-only words like です/ます, so the word detail page
- * returned "Unknown meaning" while the vocab card showed the correct definition.
- *
- * All paths now call this function so reading/meaning/meanings are always derived
- * the same way regardless of which view renders the word.
- */
-async function resolveWordMeaning(
-  wordStr: string,
-  baseForm: string,
-  lookupCache?: Map<string, any>
-): Promise<{ reading: string; meaning: string; meanings: string[] | undefined }> {
-  // Early-return for known grammatical morphemes (fix for #188).
-  //
-  // For pure-kana words like ます/ない, the dictionary waterfall reaches JMnedict
-  // which stores them as Japanese proper nouns ("Masu", "Nai"). Those are truthy
-  // non-"Unknown" strings so they would overwrite the correct grammatical definition.
-  // Checking morphemeDefinitions first prevents that path from ever running.
-  if (/^[ぁ-んー]+$/.test(wordStr)) {
-    const morphemeDef = getMorphemeDefinition(wordStr);
-    if (morphemeDef) return { reading: wordStr, meaning: morphemeDef, meanings: undefined };
-  }
-
-  // Step 1: kanji-data (fast, synchronous) — used for reading and as fallback meaning
-  let entries = getCachedDictionaryEntries(baseForm);
-  if (entries.length === 0 && baseForm !== wordStr) {
-    entries = getCachedDictionaryEntries(wordStr);
-  }
-  const { variant, entry } = findBestVariant(baseForm, entries);
-
-  let reading  = wordStr;
-  let kanjiMeaning  = "Unknown meaning";
-  let kanjiMeanings: string[] | undefined = undefined;
-
-  if (entry && variant) {
-    reading = variant.pronounced || wordStr;
-    kanjiMeaning = entry.meanings[0]?.glosses?.join(", ") || kanjiMeaning;
-    const allKanjiMeanings: string[] = [];
-    const seen = new Set<string>();
-    for (const m of entry.meanings) {
-      for (const g of (m.glosses || [])) {
-        if (!seen.has(g)) { seen.add(g); allKanjiMeanings.push(g); }
-      }
-    }
-    if (allKanjiMeanings.length > 1) kanjiMeanings = allKanjiMeanings;
-  }
-
-  // Step 2: JMDict lookup for ALL words (not just kana-only).
-  //
-  // kanji-data sense ordering is not controlled by us — it can put rare, archaic,
-  // or slang senses first (e.g. 猫→"submissive partner", 春→"New Year").
-  // JMDict results are sorted by getSenseCommonness() which deprioritises those
-  // senses. We prefer JMDict when it returns something; kanji-data is the fallback.
-  let meaning  = kanjiMeaning;
-  let meanings = kanjiMeanings;
-
-  if (dictionary) {
-    // Use the same cache for both kana-only words (original behaviour) and kanji words.
-    const cacheKey = baseForm !== wordStr ? baseForm : wordStr;
-    let dictResult: any = lookupCache?.get(cacheKey) ?? null;
-
-    if (dictResult === null) {
-      // Try baseForm first (dictionary/citation form of conjugated verbs), then surface
-      dictResult = await dictionary.lookup(baseForm);
-      if (!dictResult && baseForm !== wordStr) {
-        dictResult = await dictionary.lookup(wordStr);
-      }
-      lookupCache?.set(cacheKey, dictResult ?? false); // false = "looked up, not found"
-    }
-
-    if (dictResult && dictResult !== false) {
-      const jmdictMeaning = dictResult.meaning;
-      // Only use JMDict result when it actually has an English definition.
-      // readingAnywhere/kanjiAnywhere can match compound entries that share a
-      // character but have no English glosses — those come back as "Unknown".
-      if (jmdictMeaning && jmdictMeaning !== 'Unknown') {
-        // Keep kanji-data reading (it matched the conjugated surface form exactly);
-        // only use JMDict reading for kana-only words where kanji-data had nothing.
-        if (!reading || reading === wordStr) reading = dictResult.reading || reading;
-        meaning  = jmdictMeaning;
-        meanings = dictResult.meanings;
-      }
-    }
-  }
-
-  if (meaning === "Unknown meaning" && /^[ぁ-ん]+$/.test(wordStr)) {
-    const morphemeFallback = getMorphemeDefinition(wordStr);
-    meaning = morphemeFallback || "Kana particle / expression";
-  }
-
-  return { reading, meaning, meanings };
-}
 
 async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
@@ -310,35 +205,23 @@ async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   for (const [wordStr, baseForm] of validWords) {
     processedWords.push(wordStr);
     const start = Date.now();
-    // Try to look up using baseForm first (for conjugated verbs), then fall back to wordStr
-    const cacheHadBase = wordsCache.has(baseForm);
-    const cacheHadSurface = wordsCache.has(wordStr);
-    let entries = cacheHadBase ? wordsCache.get(baseForm)! : getCachedDictionaryEntries(baseForm);
+    const cacheHit = wordsCache.has(baseForm) || wordsCache.has(wordStr);
 
-    // If baseForm lookup failed, try the surface form
-    if (entries.length === 0 && baseForm !== wordStr) {
-      entries = cacheHadSurface ? wordsCache.get(wordStr)! : getCachedDictionaryEntries(wordStr);
-    }
+    const { reading, meaning, meanings, jlpt, joyo, score, breakdown } =
+      await wordResolver!.resolve(wordStr, baseForm, kanaLookupCache);
 
     const lookupTime = Date.now() - start;
-
-    if (cacheHadBase || cacheHadSurface) {
+    if (cacheHit) {
       cacheHits++;
       hitWords.push(wordStr);
     } else {
       cacheMisses++;
       missWords.push(wordStr);
     }
-
     if (lookupTime > 250) {
       console.log(`[API] Slow lookup: "${wordStr}" took ${lookupTime}ms`);
     }
 
-    const { reading, meaning, meanings } = await resolveWordMeaning(wordStr, baseForm, kanaLookupCache);
-
-    // Still need variant for score calculation; resolveWordMeaning handles meaning lookup
-    const { variant } = findBestVariant(baseForm, entries);
-    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
     const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
     const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
     if (meanings) wordData.meanings = meanings;
@@ -403,34 +286,23 @@ async function processTextWithTokens(text: string, tokens: any[], kanaLookupCach
   for (const [wordStr, baseForm] of validWords) {
     processedWords.push(wordStr);
     const start = Date.now();
-    // Try to look up using baseForm first (for conjugated verbs), then fall back to wordStr
-    const cacheHadBase = wordsCache.has(baseForm);
-    const cacheHadSurface = wordsCache.has(wordStr);
-    let entries = cacheHadBase ? wordsCache.get(baseForm)! : getCachedDictionaryEntries(baseForm);
+    const cacheHit = wordsCache.has(baseForm) || wordsCache.has(wordStr);
 
-    // If baseForm lookup failed, try the surface form
-    if (entries.length === 0 && baseForm !== wordStr) {
-      entries = cacheHadSurface ? wordsCache.get(wordStr)! : getCachedDictionaryEntries(wordStr);
-    }
+    const { reading, meaning, meanings, jlpt, joyo, score, breakdown } =
+      await wordResolver!.resolve(wordStr, baseForm, kanaLookupCache);
 
     const lookupTime = Date.now() - start;
-
-    if (cacheHadBase || cacheHadSurface) {
+    if (cacheHit) {
       cacheHits++;
       hitWords.push(wordStr);
     } else {
       cacheMisses++;
       missWords.push(wordStr);
     }
-
     if (lookupTime > 250) {
       console.log(`[API] Slow lookup: "${wordStr}" took ${lookupTime}ms`);
     }
 
-    const { reading, meaning, meanings } = await resolveWordMeaning(wordStr, baseForm, kanaLookupCache);
-
-    const { variant } = findBestVariant(baseForm, entries);
-    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
     const frequencyInContent = baseFormCounts.get(wordStr) ?? 1;
     const wordData: any = { word: wordStr, reading, meaning, jlpt, joyo, score, breakdown, frequencyInContent };
     if (meanings) wordData.meanings = meanings;
@@ -502,14 +374,8 @@ async function processStoryText(text: string) {
   for (const token of vocabTokens) {
     if (tokenMap.has(token.surface)) continue;
 
-    const { reading, meaning, meanings } = await resolveWordMeaning(token.surface, token.baseForm);
-
-    let entries = getCachedDictionaryEntries(token.baseForm);
-    if (entries.length === 0 && token.baseForm !== token.surface) {
-      entries = getCachedDictionaryEntries(token.surface);
-    }
-    const { variant } = findBestVariant(token.baseForm, entries);
-    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(token.surface, variant);
+    const { reading, meaning, meanings, jlpt, joyo, score, breakdown } =
+      await wordResolver!.resolve(token.surface, token.baseForm);
 
     tokenMap.set(token.surface, { word: token.surface, reading, meaning, jlpt, joyo, score, breakdown, meanings });
   }
@@ -787,7 +653,7 @@ async function startServer() {
     }
   });
 
-  app.post("/api/update-words", (req, res) => {
+  app.post("/api/update-words", async (req, res) => {
     const start = Date.now();
     try {
       const { words } = req.body;
@@ -796,22 +662,20 @@ async function startServer() {
       }
 
       console.log(`[API] /api/update-words: scoring ${words.length} words`);
-      const results = words.map((w: Record<string, unknown>) => {
+      const results = await Promise.all(words.map(async (w: Record<string, unknown>) => {
         const wordStr = w.word as string | undefined;
         if (!wordStr) return w;
 
-        const entries = getCachedDictionaryEntries(wordStr);
-        const { variant } = findBestVariant(wordStr, entries);
-        const calculated = getWordScoreBreakdown(wordStr, variant);
+        const { jlpt, joyo, score, breakdown } = await wordResolver!.resolve(wordStr, wordStr);
 
         return {
           ...w,
-          score: w.score ?? calculated.score,
-          breakdown: w.breakdown ?? calculated.breakdown,
-          jlpt: w.jlpt ?? calculated.jlpt,
-          joyo: w.joyo ?? calculated.joyo,
+          score: w.score ?? score,
+          breakdown: w.breakdown ?? breakdown,
+          jlpt: w.jlpt ?? jlpt,
+          joyo: w.joyo ?? joyo,
         };
-      });
+      }));
 
       console.log(`[API] /api/update-words: completed in ${Date.now() - start}ms`);
       res.json(results);
@@ -887,17 +751,8 @@ async function startServer() {
         return res.status(400).json({ error: 'No word provided' });
       }
 
-      // Use resolveWordMeaning so this endpoint uses the same pipeline as the
-      // extract/batch-extract paths. Previously this handler only used kanji-data
-      // and never called the dictionary, so kana-only words (です, ます, etc.)
-      // returned "Unknown meaning" here even though the vocab card showed the
-      // correct definition. Also fixes the Set-based meanings collection that
-      // lost the original sense ordering (#188).
-      const { reading, meaning, meanings } = await resolveWordMeaning(word, word);
-
-      const entries = getCachedDictionaryEntries(word);
-      const { variant, entry } = findBestVariant(word, entries);
-      const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(word, variant);
+      const { reading, meaning, meanings, variant, entry, jlpt, joyo, score, breakdown } =
+        await wordResolver!.resolve(word, word);
 
       const wordData: any = { word, reading, meaning, jlpt, joyo, score, breakdown, entry };
       if (meanings) wordData.meanings = meanings;

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -139,6 +139,11 @@ function getEntriesByKanjiLookup(wordStr: string): DictionaryEntry[] {
   return allEntries;
 }
 
+/**
+ * @internal Use WordResolver.resolve() from server endpoints; this is exposed
+ * only for cache-warming optimisations in batch-extract and for WordResolver's
+ * own pipeline internals.
+ */
 export function getCachedDictionaryEntries(wordStr: string): DictionaryEntry[] {
   if (wordsCache.has(wordStr)) return wordsCache.get(wordStr)!;
 
@@ -221,6 +226,10 @@ export function getCachedDictionaryEntries(wordStr: string): DictionaryEntry[] {
   return entries;
 }
 
+/**
+ * @internal Use WordResolver.resolve() from server endpoints; this function is
+ * part of WordResolver's private pipeline.
+ */
 export function findBestVariant(wordStr: string, entries: DictionaryEntry[]): FindBestVariantResult {
   // Track entry positions to prefer earlier entries
   const entryMap = new Map<DictionaryEntry, number>();

--- a/src/lib/wordResolver.test.ts
+++ b/src/lib/wordResolver.test.ts
@@ -56,7 +56,8 @@ describe('WordResolver – morpheme early-return guard (#188)', () => {
 
 // ── All fields returned in one call (the whole point of the class) ───────────
 
-describe('WordResolver – single-call contract', () => {
+// kanji-data cold-start can be slow on first lookup; allow 15 s for the suite.
+describe('WordResolver – single-call contract', { timeout: 15000 }, () => {
   it('resolve() returns all required fields without extra calls', async () => {
     const resolver = new WordResolver(null);
     const result = await resolver.resolve('猫', '猫');

--- a/src/lib/wordResolver.test.ts
+++ b/src/lib/wordResolver.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { WordResolver } from './wordResolver.js';
+
+// ---------------------------------------------------------------------------
+// #197 – WordResolver class
+//
+// resolveWordMeaning() in server.ts was the fix for #188, but several
+// handlers still bypassed it by calling getCachedDictionaryEntries /
+// findBestVariant / getWordScoreBreakdown separately. WordResolver bundles
+// the entire pipeline into a single public method so endpoints cannot half-use
+// it.
+//
+// These tests pin the specific regression cases from #188: ます/ない being
+// shadowed by JMnedict proper nouns, and 猫/春 having slang/archaic senses
+// promoted to primary meaning.
+// ---------------------------------------------------------------------------
+
+/** Minimal duck-typed dictionary stand-in for injection in tests. */
+function makeMockDictionary(
+  lookupMap: Record<string, { meaning: string; reading?: string; meanings?: string[] } | null>
+) {
+  return {
+    lookup: async (word: string) => lookupMap[word] ?? null,
+  };
+}
+
+// ── Morpheme early-return guard (fix for #188) ───────────────────────────────
+
+describe('WordResolver – morpheme early-return guard (#188)', () => {
+  it('ます: returns polite suffix definition even when a dictionary would return "Masu"', async () => {
+    // JMnedict stores ます as the proper noun "Masu". Without the guard the
+    // JMDict/JMnedict result would overwrite the correct grammatical definition.
+    const dict = makeMockDictionary({ ます: { meaning: 'Masu', reading: 'ます' } });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('ます', 'ます');
+    expect(result.meaning).toMatch(/polite/i);
+    expect(result.meaning).not.toBe('Masu');
+  });
+
+  it('ない: returns negation definition even when a dictionary would return "Nai"', async () => {
+    const dict = makeMockDictionary({ ない: { meaning: 'Nai', reading: 'ない' } });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('ない', 'ない');
+    expect(result.meaning).toMatch(/negat/i);
+    expect(result.meaning).not.toBe('Nai');
+  });
+
+  it('です: returns copula definition, not a JMnedict proper noun', async () => {
+    const dict = makeMockDictionary({ です: { meaning: 'Desu', reading: 'です' } });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('です', 'です');
+    expect(result.meaning).toMatch(/copula|to be|polite/i);
+    expect(result.meaning).not.toBe('Desu');
+  });
+});
+
+// ── All fields returned in one call (the whole point of the class) ───────────
+
+describe('WordResolver – single-call contract', () => {
+  it('resolve() returns all required fields without extra calls', async () => {
+    const resolver = new WordResolver(null);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result).toHaveProperty('reading');
+    expect(result).toHaveProperty('meaning');
+    expect(result).toHaveProperty('meanings');  // may be undefined — key must exist
+    expect(result).toHaveProperty('variant');
+    expect(result).toHaveProperty('entry');
+    expect(result).toHaveProperty('jlpt');
+    expect(result).toHaveProperty('joyo');
+    expect(result).toHaveProperty('score');
+    expect(result).toHaveProperty('breakdown');
+  });
+
+  it('breakdown contains expected sub-fields', async () => {
+    const resolver = new WordResolver(null);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result.breakdown).toHaveProperty('jlptScore');
+    expect(result.breakdown).toHaveProperty('joyoPenalty');
+    expect(result.breakdown).toHaveProperty('highestGrade');
+    expect(result.breakdown).toHaveProperty('freqPenalty');
+    expect(result.breakdown).toHaveProperty('jlptValues');
+    expect(result.breakdown).toHaveProperty('gradeValues');
+    expect(result.breakdown).toHaveProperty('priorities');
+  });
+
+  it('score is within the documented 1–100 range', async () => {
+    const resolver = new WordResolver(null);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result.score).toBeGreaterThanOrEqual(1);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── JMDict preferred over kanji-data when available ─────────────────────────
+
+describe('WordResolver – JMDict preference over kanji-data', () => {
+  it('uses JMDict meaning when it provides a non-Unknown result', async () => {
+    // kanji-data might surface a less-common sense; JMDict should win.
+    const dict = makeMockDictionary({
+      猫: { meaning: 'cat', reading: 'ねこ', meanings: ['cat'] },
+    });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result.meaning).toBe('cat');
+  });
+
+  it('falls back to kanji-data meaning when JMDict returns null', async () => {
+    const dict = makeMockDictionary({ 猫: null });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('猫', '猫');
+    // kanji-data has 猫 — meaning must be a non-empty string, not "Unknown meaning"
+    expect(result.meaning).toBeTruthy();
+    expect(result.meaning).not.toBe('');
+  });
+
+  it('does not replace meaning when JMDict returns "Unknown"', async () => {
+    const dict = makeMockDictionary({ 猫: { meaning: 'Unknown', reading: 'ねこ' } });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result.meaning).not.toBe('Unknown');
+  });
+
+  it('result includes meanings array when JMDict provides multiple senses', async () => {
+    const dict = makeMockDictionary({
+      猫: { meaning: 'cat', reading: 'ねこ', meanings: ['cat', 'pussy'] },
+    });
+    const resolver = new WordResolver(dict);
+    const result = await resolver.resolve('猫', '猫');
+    expect(result.meanings).toEqual(['cat', 'pussy']);
+  });
+});
+
+// ── lookupCache deduplication across calls ───────────────────────────────────
+
+describe('WordResolver – lookupCache', () => {
+  it('does not call dictionary a second time for the same word when cache is provided', async () => {
+    let callCount = 0;
+    const dict = {
+      lookup: async (word: string) => {
+        callCount++;
+        return { meaning: 'cat', reading: 'ねこ' };
+      },
+    };
+    const resolver = new WordResolver(dict);
+    const cache = new Map<string, any>();
+    await resolver.resolve('猫', '猫', cache);
+    await resolver.resolve('猫', '猫', cache);
+    expect(callCount).toBe(1);
+  });
+});
+
+// ── Kana-only fallback ────────────────────────────────────────────────────────
+
+describe('WordResolver – kana-only fallback', () => {
+  it('pure kana with no morpheme definition and no dictionary falls back gracefully', async () => {
+    const resolver = new WordResolver(null);
+    // ぽ has no morpheme definition and no kanji-data entry
+    const result = await resolver.resolve('ぽ', 'ぽ');
+    expect(result.meaning).toBe('Kana particle / expression');
+  });
+
+  it('pure kana morpheme is returned without calling the dictionary', async () => {
+    let callCount = 0;
+    const dict = { lookup: async () => { callCount++; return null; } };
+    const resolver = new WordResolver(dict);
+    await resolver.resolve('ます', 'ます');
+    expect(callCount).toBe(0);
+  });
+});

--- a/src/lib/wordResolver.ts
+++ b/src/lib/wordResolver.ts
@@ -1,0 +1,142 @@
+import {
+  getCachedDictionaryEntries,
+  findBestVariant,
+  getWordScoreBreakdown,
+  DictionaryVariant,
+  DictionaryEntry,
+} from './scoring.js';
+import { getMorphemeDefinition } from './morphemeDefinitions.js';
+
+export interface WordResolution {
+  reading: string;
+  meaning: string;
+  meanings: string[] | undefined;
+  variant: DictionaryVariant | null;
+  entry: DictionaryEntry | null;
+  jlpt: number;
+  joyo: boolean;
+  score: number;
+  breakdown: {
+    jlptScore: number;
+    joyoPenalty: number;
+    highestGrade: number | null;
+    freqPenalty: number;
+    jlptValues: number[];
+    gradeValues: number[];
+    priorities: string[];
+  };
+}
+
+interface DictionaryLike {
+  lookup(word: string): Promise<{ reading?: string; meaning?: string; meanings?: string[] } | null | false>;
+}
+
+/**
+ * Single entry point for word resolution (#197).
+ *
+ * Bundles kanji-data lookup → JMDict lookup → morpheme fallback → score
+ * calculation into one call so server endpoints cannot accidentally use only
+ * part of the pipeline (the pattern that caused #188).
+ *
+ * Inject a DictionaryLike (DictionaryManager) at construction time; pass null
+ * when the dictionary is not yet available (score-only paths, tests).
+ */
+export class WordResolver {
+  constructor(private dictionary: DictionaryLike | null = null) {}
+
+  async resolve(
+    wordStr: string,
+    baseForm: string,
+    lookupCache?: Map<string, any>
+  ): Promise<WordResolution> {
+    // (1) Early-return for known grammatical morphemes.
+    //
+    // For pure-kana words like ます/ない, the waterfall reaches JMnedict which
+    // stores them as proper nouns ("Masu", "Nai"). Checking morphemeDefinitions
+    // first prevents that from ever running (#188).
+    if (/^[ぁ-んー]+$/.test(wordStr)) {
+      const morphemeDef = getMorphemeDefinition(wordStr);
+      if (morphemeDef) {
+        const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, null);
+        return {
+          reading: wordStr,
+          meaning: morphemeDef,
+          meanings: undefined,
+          variant: null,
+          entry: null,
+          jlpt,
+          joyo,
+          score,
+          breakdown,
+        };
+      }
+    }
+
+    // (2) kanji-data (fast, synchronous) — reading + fallback meaning.
+    let entries = getCachedDictionaryEntries(baseForm);
+    if (entries.length === 0 && baseForm !== wordStr) {
+      entries = getCachedDictionaryEntries(wordStr);
+    }
+    const { variant, entry } = findBestVariant(baseForm, entries);
+
+    let reading = wordStr;
+    let kanjiMeaning = 'Unknown meaning';
+    let kanjiMeanings: string[] | undefined = undefined;
+
+    if (entry && variant) {
+      reading = variant.pronounced || wordStr;
+      kanjiMeaning = entry.meanings[0]?.glosses?.join(', ') || kanjiMeaning;
+      const allKanjiMeanings: string[] = [];
+      const seen = new Set<string>();
+      for (const m of entry.meanings) {
+        for (const g of m.glosses || []) {
+          if (!seen.has(g)) { seen.add(g); allKanjiMeanings.push(g); }
+        }
+      }
+      if (allKanjiMeanings.length > 1) kanjiMeanings = allKanjiMeanings;
+    }
+
+    // (3) JMDict lookup — preferred when it returns a real gloss.
+    //
+    // kanji-data sense ordering is uncontrolled (can surface rare/archaic/slang
+    // senses first, e.g. 猫→"submissive partner", 春→"New Year"). JMDict results
+    // are sorted by getSenseCommonness() which deprioritises those senses.
+    let meaning = kanjiMeaning;
+    let meanings = kanjiMeanings;
+
+    if (this.dictionary) {
+      const cacheKey = baseForm !== wordStr ? baseForm : wordStr;
+      let dictResult: any = lookupCache?.get(cacheKey) ?? null;
+
+      if (dictResult === null) {
+        dictResult = await this.dictionary.lookup(baseForm);
+        if (!dictResult && baseForm !== wordStr) {
+          dictResult = await this.dictionary.lookup(wordStr);
+        }
+        lookupCache?.set(cacheKey, dictResult ?? false); // false = "looked up, not found"
+      }
+
+      if (dictResult && dictResult !== false) {
+        const jmdictMeaning = dictResult.meaning;
+        if (jmdictMeaning && jmdictMeaning !== 'Unknown') {
+          // Keep kanji-data reading for conjugated surface forms; only use JMDict
+          // reading for kana-only words where kanji-data had nothing.
+          if (!reading || reading === wordStr) reading = dictResult.reading || reading;
+          meaning = jmdictMeaning;
+          meanings = dictResult.meanings;
+        }
+      }
+    }
+
+    // (4) Final kana-only fallback.
+    if (meaning === 'Unknown meaning' && /^[ぁ-ん]+$/.test(wordStr)) {
+      const morphemeFallback = getMorphemeDefinition(wordStr);
+      meaning = morphemeFallback || 'Kana particle / expression';
+    }
+
+    // (5) Score calculation — always uses the same variant selected above.
+    const { jlpt, joyo, score, breakdown } = getWordScoreBreakdown(wordStr, variant);
+
+    return { reading, meaning, meanings, variant, entry, jlpt, joyo, score, breakdown };
+  }
+}


### PR DESCRIPTION
## Summary
Refactors the word resolution pipeline into a dedicated `WordResolver` class to prevent endpoints from accidentally bypassing parts of the lookup logic. This fixes a regression pattern where some handlers were calling `getCachedDictionaryEntries` / `findBestVariant` / `getWordScoreBreakdown` separately instead of using the unified `resolveWordMeaning` function.

## Key Changes

- **New `WordResolver` class** (`src/lib/wordResolver.ts`):
  - Bundles the entire word resolution pipeline (kanji-data → JMDict → morpheme fallback → scoring) into a single `resolve()` method
  - Ensures all endpoints use the same lookup logic regardless of code path
  - Accepts an optional `DictionaryLike` interface for dependency injection (supports null for score-only paths)
  - Returns a comprehensive `WordResolution` object with reading, meaning, meanings, variant, entry, and all scoring fields

- **Updated server.ts**:
  - Removes the `resolveWordMeaning()` function (now encapsulated in `WordResolver`)
  - Instantiates `wordResolver` during dictionary initialization
  - Refactors `processText()`, `processTextWithTokens()`, `processStoryText()`, `/api/update-words`, and `/api/word/:word` endpoints to call `wordResolver.resolve()` instead of manually chaining lookup functions
  - Simplifies endpoint logic by eliminating duplicate cache-checking and variant-lookup code

- **Updated scoring.ts**:
  - Adds `@internal` JSDoc comments to `getCachedDictionaryEntries()` and `findBestVariant()` to indicate they should only be called from `WordResolver` or cache-warming paths

- **New test suite** (`src/lib/wordResolver.test.ts`):
  - Tests the morpheme early-return guard (fixes for #188: ます/ない/です)
  - Verifies all required fields are returned in a single call
  - Tests JMDict preference over kanji-data
  - Tests lookupCache deduplication
  - Tests kana-only fallback behavior

## Implementation Details

The `WordResolver` pipeline follows this order:
1. **Morpheme guard**: Pure-kana words (ぁ-ん) check morpheme definitions first to prevent JMnedict proper nouns from shadowing grammatical definitions
2. **kanji-data lookup**: Fast synchronous lookup for reading and fallback meaning
3. **JMDict lookup**: Preferred when it returns a non-"Unknown" result (better sense ordering via `getSenseCommonness()`)
4. **Kana-only fallback**: Final safety net for pure-kana words with no morpheme definition
5. **Score calculation**: Always uses the variant selected in step 2

This ensures consistent behavior across all endpoints and prevents the regression pattern that caused #188.

https://claude.ai/code/session_01AjHjYWFN3KjzafWDZMCFMZ