### PR TITLE
Fix SIGTERM handling to allow proper process termination

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1028,10 +1028,6 @@ async function startServer() {
     }
   })();
 
-  // Keep server alive even if parent process tries to shut down
-  let shutdownRequested = false;
-  let shutdownAttempts = 0;
-
   // Save database on shutdown
   process.on('SIGINT', () => {
     console.log('\n[Server] Shutting down, saving database...');
@@ -1040,20 +1036,10 @@ async function startServer() {
   });
 
   process.on('SIGTERM', () => {
-    shutdownAttempts++;
-    console.log(`[Server] Received SIGTERM (attempt ${shutdownAttempts}), ignoring gracefully...`);
-
-    if (!shutdownRequested) {
-      shutdownRequested = true;
-      console.log('[Server] Server will continue running. Press Ctrl+C to stop.');
-    }
-    // Don't exit - server should stay alive
+    console.log('[Server] Received SIGTERM, shutting down gracefully...');
+    saveDatabase();
+    process.exit(0);
   });
-
-  // Prevent the process from exiting due to empty event loop
-  setInterval(() => {
-    // Keep-alive interval to prevent process exit
-  }, 30000);
 }
 
 startServer().catch((err) => {

--- a/server.ts
+++ b/server.ts
@@ -1035,9 +1035,14 @@ async function startServer() {
     process.exit(0);
   });
 
+  // SIGTERM was previously ignored (commit 1b49e85) to survive GitHub Codespaces idle
+  // timeouts, but that breaks docker stop / systemd / k8s. If Codespaces kills the server
+  // on idle, restart it — don't make the server unkillable to compensate.
   process.on('SIGTERM', () => {
     console.log('[Server] Received SIGTERM, shutting down gracefully...');
-    saveDatabase();
+    try { saveDatabase(); } catch (err) {
+      console.error('[Server] Error saving database on shutdown:', err);
+    }
     process.exit(0);
   });
 }


### PR DESCRIPTION
## Summary
This change restores proper SIGTERM signal handling to allow the server process to be terminated gracefully by container orchestration systems, systemd, and Docker. Previously, SIGTERM was intentionally ignored to work around GitHub Codespaces idle timeouts, but this prevented legitimate shutdown mechanisms from working.

## Key Changes
- **Removed SIGTERM suppression**: Changed SIGTERM handler from ignoring the signal to properly shutting down the server
- **Removed keep-alive mechanisms**: Deleted the `shutdownRequested` flag, `shutdownAttempts` counter, and the 30-second keep-alive interval that were preventing process exit
- **Added graceful shutdown**: SIGTERM now saves the database and exits cleanly, matching SIGINT behavior
- **Updated rationale**: Added explanatory comment clarifying that if Codespaces kills the server on idle, it should be restarted rather than made unkillable

## Implementation Details
- Both SIGINT and SIGTERM now follow the same shutdown pattern: save database and exit
- Error handling added to SIGTERM to catch and log any database save failures
- The server will no longer artificially keep itself alive, allowing proper termination by external process managers

https://claude.ai/code/session_01HmHsEUctaKRUFxFYWTuAHK