### PR TITLE
Build and set production environment for start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compress-cache": "bash scripts/compress-cache.sh",
     "postinstall": "bash scripts/setup-sudachi.sh || echo 'ℹ️  Sudachi setup skipped (Rust not installed). Run: npm run setup-sudachi'; bash scripts/setup-cache.sh; node scripts/print-version.js",
     "dev": "node scripts/print-version.js && tsx server.ts",
-    "start": "node server.ts",
+    "start": "npm run build && NODE_ENV=production tsx server.ts",
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
Updated the `start` npm script to build the project and set the production environment before running the server.

## Key Changes
- Modified the `start` script to run `npm run build` before starting the server
- Added `NODE_ENV=production` environment variable when running the server in production mode
- Changed from directly running `node server.ts` to using `tsx server.ts` for consistency with the dev script

## Implementation Details
The start script now follows a proper production deployment pattern:
1. Builds the project using Vite (`npm run build`)
2. Sets the Node environment to production
3. Runs the server with tsx (TypeScript executor)

This ensures that the application is properly compiled and optimized before serving in production, and that any environment-dependent code behaves correctly.

https://claude.ai/code/session_01TyBF8aTb2uqzTru3zJeqyi