### PR TITLE
Filter out partial verb stems ending in っ from word extraction

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,7 +15,7 @@ import { ensureJmnedictPrepared } from "./src/lib/jmnedict-utils.js";
 import { getMorphemeDefinition } from "./src/lib/morphemeDefinitions.js";
 import { loadStoriesFromDisk, loadMusicFromDisk, loadVideosFromDisk } from "./src/lib/storyLoader.js";
 import { initDatabase, WordsCache, JishoCache, ContentWordsStore, saveDatabase } from "./src/lib/database.js";
-import { isPunctuation, isSingleKana } from "./src/lib/extraction-helpers.js";
+import { isPunctuation, isSingleKana, looksLikePartialStem } from "./src/lib/extraction-helpers.js";
 import type { WorkerInitData, WorkerOutMessage } from "./src/lib/extraction-worker.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -438,7 +438,7 @@ async function runBatchExtract(texts: { id: string; text: string }[]): Promise<B
       const surface = token.surface;
       if (surface.trim() === '' || isPunctuation(surface) || isSingleKana(surface)) continue;
       if (/^[ぁ-ん]+$/.test(surface) || /^[ァ-ヴー]+$/.test(surface)) {
-        uniqueKanaWords.add(surface);
+        if (!looksLikePartialStem(surface)) uniqueKanaWords.add(surface);
       }
     }
   }

--- a/src/lib/extraction-helpers.test.ts
+++ b/src/lib/extraction-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord } from './extraction-helpers.js';
+import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord, looksLikePartialStem } from './extraction-helpers.js';
 
 describe('extraction helpers', () => {
   describe('isPunctuation', () => {
@@ -90,6 +90,36 @@ describe('extraction helpers', () => {
 
     it('returns false for mixed kanji-katakana', () => {
       expect(isKatakanaWord('日テレ')).toBe(false);
+    });
+  });
+
+  describe('looksLikePartialStem', () => {
+    it('returns true for verb stems ending in small tsu (っ)', () => {
+      // These are cut-off conjugation artifacts — no valid Japanese dictionary
+      // entry ends in っ. Sending them to Jisho returns geographic junk like
+      // "Molazzana" (the original bug in issue #174).
+      expect(looksLikePartialStem('もらっ')).toBe(true);
+      expect(looksLikePartialStem('走っ')).toBe(true);
+      expect(looksLikePartialStem('やっ')).toBe(true);
+      expect(looksLikePartialStem('あっ')).toBe(true);
+    });
+
+    it('returns false for complete hiragana words', () => {
+      expect(looksLikePartialStem('もらう')).toBe(false);
+      expect(looksLikePartialStem('ありがとう')).toBe(false);
+      expect(looksLikePartialStem('です')).toBe(false);
+      expect(looksLikePartialStem('ねこ')).toBe(false);
+    });
+
+    it('returns false for words with っ in the middle (valid dictionary entries)', () => {
+      // きって (stamp), もって (holding) etc. are valid words
+      expect(looksLikePartialStem('きって')).toBe(false);
+      expect(looksLikePartialStem('もって')).toBe(false);
+      expect(looksLikePartialStem('まって')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(looksLikePartialStem('')).toBe(false);
     });
   });
 

--- a/src/lib/extraction-helpers.ts
+++ b/src/lib/extraction-helpers.ts
@@ -33,3 +33,13 @@ export function isHiraganaWord(s: string): boolean {
 export function isKatakanaWord(s: string): boolean {
   return s.length > 0 && /^[ァ-ヴー]+$/.test(s);
 }
+
+/**
+ * Returns true when a kana word ends in small-tsu (っ), indicating it is a
+ * cut-off verb-stem conjugation artifact (e.g. もらっ, 走っ) rather than a
+ * complete dictionary entry.  No valid Japanese dictionary form ends in っ, so
+ * sending these to Jisho returns geographic noise like "Molazzana" (#174).
+ */
+export function looksLikePartialStem(s: string): boolean {
+  return s.length > 0 && s.endsWith('っ');
+}

--- a/src/lib/extraction-worker.ts
+++ b/src/lib/extraction-worker.ts
@@ -28,7 +28,7 @@ import {
   getWordScoreBreakdown,
 } from './scoring.js';
 import { getMorphemeDefinition } from './morphemeDefinitions.js';
-import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord } from './extraction-helpers.js';
+import { PARTICLES, isPunctuation, isSingleKana, isHiraganaWord, isKatakanaWord, looksLikePartialStem } from './extraction-helpers.js';
 
 // ---------------------------------------------------------------------------
 // Public types (imported by server.ts for type-safety on the message channel)
@@ -218,7 +218,7 @@ async function extractBatch(items: BatchItem[]): Promise<BatchResult[]> {
     for (const token of item.tokens) {
       const s = token.surface;
       if (s.trim() === '' || isPunctuation(s) || isSingleKana(s)) continue;
-      if (isHiraganaWord(s) || isKatakanaWord(s)) uniqueKanaWords.add(s);
+      if ((isHiraganaWord(s) || isKatakanaWord(s)) && !looksLikePartialStem(s)) uniqueKanaWords.add(s);
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds a new helper function `looksLikePartialStem()` to detect and filter out incomplete verb conjugations that end in small-tsu (っ). These partial stems were being sent to Jisho, resulting in irrelevant geographic noise in search results.

## Key Changes
- Added `looksLikePartialStem()` function to `extraction-helpers.ts` that identifies words ending in っ, which are never valid dictionary entries in Japanese
- Updated word extraction logic in both `server.ts` and `extraction-worker.ts` to skip words matching this pattern before adding them to the unique words collection
- Added comprehensive test coverage for the new function, including:
  - Verification that verb stems ending in っ are detected (もらっ, 走っ, etc.)
  - Confirmation that complete hiragana words are not filtered
  - Confirmation that valid dictionary entries with っ in the middle (きって, もって) are preserved
  - Edge case handling for empty strings

## Implementation Details
The function performs a simple check: `s.length > 0 && s.endsWith('っ')`. This targets the root cause of issue #174 where partial conjugation artifacts like "もらっ" were being looked up and returning unrelated results like "Molazzana".

The filtering is applied consistently across both the batch extraction in `server.ts` and the worker extraction in `extraction-worker.ts` to ensure partial stems are excluded from the unique words collection.

https://claude.ai/code/session_01NnBnxeeQGxy53BANdUW6nV