### PR TITLE
Add comprehensive filtering, sorting, and search to home view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,65 @@ import { Content } from './data/content';
 import { applyWaniKaniToWords, useContentData } from './hooks/useContentData';
 import { useUrlRouting } from './hooks/useUrlRouting';
 import { getAllContentWords } from './lib/api';
+import {
+  applyContentFilters,
+  collectLevels,
+  collectTags,
+  DEFAULT_FILTERS,
+  sortContent,
+  type ContentFilters,
+  type LengthFilter,
+  type SearchScope,
+  type SortBy,
+  type SortDir,
+} from './lib/contentFilters';
 import { WordInfo } from './types';
 import HomeView from './views/HomeView';
 import ScoringView from './views/ScoringView';
 import VocabView from './views/VocabView';
+
+const HOME_FILTERS_KEY = 'homeFilters';
+
+interface PersistedHomeFilters {
+  searchQuery: string;
+  searchScope: SearchScope[];
+  typeFilter: string[];
+  levelFilter: string[];
+  tagFilter: string[];
+  lengthFilter: LengthFilter;
+  comprehensionRange: [number, number];
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
+function loadPersistedFilters(): {
+  filters: ContentFilters;
+  sortBy: SortBy;
+  sortDir: SortDir;
+} {
+  const fallback = { filters: { ...DEFAULT_FILTERS }, sortBy: 'difficulty' as SortBy, sortDir: 'asc' as SortDir };
+  try {
+    const raw = localStorage.getItem(HOME_FILTERS_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<PersistedHomeFilters>;
+    return {
+      filters: {
+        searchQuery: parsed.searchQuery ?? '',
+        searchScope: new Set(parsed.searchScope ?? ['title', 'description']),
+        typeFilter: new Set(parsed.typeFilter ?? []),
+        levelFilter: new Set(parsed.levelFilter ?? []),
+        tagFilter: new Set(parsed.tagFilter ?? []),
+        lengthFilter: parsed.lengthFilter ?? 'all',
+        comprehensionRange: parsed.comprehensionRange ?? [0, 100],
+      },
+      sortBy: parsed.sortBy ?? 'difficulty',
+      sortDir: parsed.sortDir ?? 'asc',
+    };
+  } catch (e) {
+    console.error('Failed to parse persisted home filters:', e);
+    return fallback;
+  }
+}
 
 export default function App() {
   const {
@@ -68,10 +123,17 @@ export default function App() {
     fetchContent();
   }, []);
 
-  // Filter state for home view (#12, #13)
-  const [searchQuery, setSearchQuery] = useState('');
-  const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
-  const [comprehensionFilter, setComprehensionFilter] = useState<'all' | 'almost' | 'ready'>('all');
+  // Filter / sort state for home view — persisted to localStorage under HOME_FILTERS_KEY.
+  const persisted = useMemo(() => loadPersistedFilters(), []);
+  const [searchQuery, setSearchQuery] = useState(persisted.filters.searchQuery);
+  const [searchScope, setSearchScope] = useState<Set<SearchScope>>(persisted.filters.searchScope);
+  const [typeFilter, setTypeFilter] = useState<Set<string>>(persisted.filters.typeFilter);
+  const [levelFilter, setLevelFilter] = useState<Set<string>>(persisted.filters.levelFilter);
+  const [tagFilter, setTagFilter] = useState<Set<string>>(persisted.filters.tagFilter);
+  const [lengthFilter, setLengthFilter] = useState<LengthFilter>(persisted.filters.lengthFilter);
+  const [comprehensionRange, setComprehensionRange] = useState<[number, number]>(persisted.filters.comprehensionRange);
+  const [sortBy, setSortBy] = useState<SortBy>(persisted.sortBy);
+  const [sortDir, setSortDir] = useState<SortDir>(persisted.sortDir);
 
   const { navigateToWord } = useUrlRouting({ setSelectedWord });
 
@@ -207,27 +269,39 @@ export default function App() {
     }
   }, [ALL_CONTENT.length, batchExtractionAttempted, wkData]);
 
-  // Sort and filter content (#11, #12, #13)
+  const filters = useMemo<ContentFilters>(() => ({
+    searchQuery,
+    searchScope,
+    typeFilter,
+    levelFilter,
+    tagFilter,
+    lengthFilter,
+    comprehensionRange,
+  }), [searchQuery, searchScope, typeFilter, levelFilter, tagFilter, lengthFilter, comprehensionRange]);
+
+  // Persist filter/sort selections so they survive a reload.
+  useEffect(() => {
+    const payload: PersistedHomeFilters = {
+      searchQuery,
+      searchScope: Array.from(searchScope),
+      typeFilter: Array.from(typeFilter),
+      levelFilter: Array.from(levelFilter),
+      tagFilter: Array.from(tagFilter),
+      lengthFilter,
+      comprehensionRange,
+      sortBy,
+      sortDir,
+    };
+    localStorage.setItem(HOME_FILTERS_KEY, JSON.stringify(payload));
+  }, [searchQuery, searchScope, typeFilter, levelFilter, tagFilter, lengthFilter, comprehensionRange, sortBy, sortDir]);
+
   const sortedContent = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
-    return [...ALL_CONTENT]
-      .filter(c => {
-        if (q && !c.title.toLowerCase().includes(q)) return false;
-        if (typeFilter.size > 0 && !typeFilter.has(c.type)) return false;
-        const status = getContentStatus(c.id);
-        if (status.totalCount === 0) return comprehensionFilter === 'all'; // unloaded items only show in 'all'
-        if (comprehensionFilter === 'almost') return status.comprehension >= 90 && status.comprehension < 100;
-        if (comprehensionFilter === 'ready') return status.comprehension === 100;
-        return true;
-      })
-      .sort((a, b) => {
-        const statusA = getContentStatus(a.id);
-        const statusB = getContentStatus(b.id);
-        if (statusA.totalCount === 0 && statusB.totalCount !== 0) return 1;
-        if (statusA.totalCount !== 0 && statusB.totalCount === 0) return -1;
-        return statusA.score - statusB.score;
-      });
-  }, [ALL_CONTENT, searchQuery, typeFilter, comprehensionFilter, getContentStatus]);
+    const filtered = applyContentFilters(ALL_CONTENT, getContentStatus, filters);
+    return sortContent(filtered, getContentStatus, contentVocab, sortBy, sortDir);
+  }, [ALL_CONTENT, filters, sortBy, sortDir, getContentStatus, contentVocab]);
+
+  const availableTags = useMemo(() => collectTags(ALL_CONTENT), [ALL_CONTENT]);
+  const availableLevels = useMemo(() => collectLevels(ALL_CONTENT), [ALL_CONTENT]);
 
   const visibleContent = sortedContent.slice(0, displayCount);
 
@@ -240,7 +314,54 @@ export default function App() {
     setDisplayCount(12);
   };
 
-  const hasActiveFilters = searchQuery.trim() !== '' || typeFilter.size > 0 || comprehensionFilter !== 'all';
+  const toggleLevelFilter = (level: string) => {
+    setLevelFilter(prev => {
+      const next = new Set(prev);
+      next.has(level) ? next.delete(level) : next.add(level);
+      return next;
+    });
+    setDisplayCount(12);
+  };
+
+  const toggleTagFilter = (tag: string) => {
+    setTagFilter(prev => {
+      const next = new Set(prev);
+      next.has(tag) ? next.delete(tag) : next.add(tag);
+      return next;
+    });
+    setDisplayCount(12);
+  };
+
+  const toggleSearchScope = (scope: SearchScope) => {
+    setSearchScope(prev => {
+      const next = new Set(prev);
+      next.has(scope) ? next.delete(scope) : next.add(scope);
+      // Don't allow zero scopes — re-enable title if user removed the last one.
+      if (next.size === 0) next.add('title');
+      return next;
+    });
+    setDisplayCount(12);
+  };
+
+  const clearAllFilters = () => {
+    setSearchQuery('');
+    setSearchScope(new Set(['title', 'description']));
+    setTypeFilter(new Set());
+    setLevelFilter(new Set());
+    setTagFilter(new Set());
+    setLengthFilter('all');
+    setComprehensionRange([0, 100]);
+    setDisplayCount(12);
+  };
+
+  const hasActiveFilters =
+    searchQuery.trim() !== '' ||
+    typeFilter.size > 0 ||
+    levelFilter.size > 0 ||
+    tagFilter.size > 0 ||
+    lengthFilter !== 'all' ||
+    comprehensionRange[0] !== 0 ||
+    comprehensionRange[1] !== 100;
 
   const comprehensionColor = (pct: number) => {
     if (pct >= 90) return 'text-green-700 bg-green-50 border-green-200';
@@ -392,15 +513,29 @@ export default function App() {
 
         {view === 'home' && (
           <HomeView
-            setSearchQuery={setSearchQuery}
             setDisplayCount={setDisplayCount}
             searchQuery={searchQuery}
-            toggleTypeFilter={toggleTypeFilter}
+            setSearchQuery={setSearchQuery}
+            searchScope={searchScope}
+            toggleSearchScope={toggleSearchScope}
             typeFilter={typeFilter}
-            setComprehensionFilter={setComprehensionFilter}
-            comprehensionFilter={comprehensionFilter}
-            setTypeFilter={setTypeFilter}
+            toggleTypeFilter={toggleTypeFilter}
+            levelFilter={levelFilter}
+            toggleLevelFilter={toggleLevelFilter}
+            availableLevels={availableLevels}
+            tagFilter={tagFilter}
+            toggleTagFilter={toggleTagFilter}
+            availableTags={availableTags}
+            lengthFilter={lengthFilter}
+            setLengthFilter={setLengthFilter}
+            comprehensionRange={comprehensionRange}
+            setComprehensionRange={setComprehensionRange}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            sortDir={sortDir}
+            setSortDir={setSortDir}
             hasActiveFilters={hasActiveFilters}
+            onClearFilters={clearAllFilters}
             getContentStatus={getContentStatus}
             visibleContent={visibleContent}
             loadingContent={loadingContent}

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -10,6 +10,9 @@ export interface Content {
   text: string; // The transcript or story
   mediaUrl?: string;
   imageUrl?: string;
+  level?: string;     // JLPT level / difficulty band from metadata (e.g. "N5", "beginner")
+  tags?: string[];    // Free-form tags from metadata
+  dateAdded?: string; // ISO date string from metadata (when content was added)
 }
 
 export interface Story extends Content {

--- a/src/lib/contentFilters.test.ts
+++ b/src/lib/contentFilters.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeLevel,
+  countSentences,
+  hardestKanjiScore,
+  matchesSearch,
+  applyContentFilters,
+  sortContent,
+  collectTags,
+  DEFAULT_FILTERS,
+  type ContentFilters,
+  type SortBy,
+  type SortDir,
+  type ContentStatus,
+} from './contentFilters';
+import type { Content } from '../data/content';
+import type { WordInfo } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mkContent = (over: Partial<Content>): Content => ({
+  id: over.id ?? 'x',
+  title: over.title ?? 'Title',
+  type: over.type ?? 'story',
+  description: over.description ?? '',
+  text: over.text ?? '',
+  level: over.level,
+  tags: over.tags,
+  dateAdded: over.dateAdded,
+  mediaUrl: over.mediaUrl,
+  imageUrl: over.imageUrl,
+});
+
+const mkStatus = (over: Partial<ContentStatus> = {}): ContentStatus => ({
+  comprehension: 0,
+  totalCount: 0,
+  unknownCount: 0,
+  score: 0,
+  ...over,
+});
+
+const mkWord = (jlptScore: number): WordInfo => ({
+  word: '',
+  reading: '',
+  meaning: '',
+  jlpt: 0,
+  joyo: false,
+  score: 0,
+  breakdown: {
+    jlptScore,
+    joyoPenalty: 0,
+    freqPenalty: 0,
+    jlptValues: [],
+    gradeValues: [],
+    priorities: [],
+  },
+});
+
+// ---------------------------------------------------------------------------
+// normalizeLevel
+// ---------------------------------------------------------------------------
+
+describe('normalizeLevel', () => {
+  it('maps JLPT-style values', () => {
+    expect(normalizeLevel('N5')).toBe('N5');
+    expect(normalizeLevel('n4')).toBe('N4');
+    expect(normalizeLevel('JLPT N3')).toBe('N3');
+  });
+  it('maps difficulty bands', () => {
+    expect(normalizeLevel('beginner')).toBe('beginner');
+    expect(normalizeLevel('Intermediate')).toBe('intermediate');
+    expect(normalizeLevel('ADVANCED')).toBe('advanced');
+  });
+  it('returns unknown for missing/empty', () => {
+    expect(normalizeLevel(undefined)).toBe('unknown');
+    expect(normalizeLevel('')).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSentences
+// ---------------------------------------------------------------------------
+
+describe('countSentences', () => {
+  it('counts on Japanese terminators', () => {
+    expect(countSentences('猫が好きです。本を読みました。')).toBe(2);
+  });
+  it('counts on western terminators', () => {
+    expect(countSentences('Hello world! How are you? Fine.')).toBe(3);
+  });
+  it('counts blank lines / newlines as separators (for songs/poems)', () => {
+    expect(countSentences('行一\n行二\n行三')).toBe(3);
+  });
+  it('returns 0 for empty text', () => {
+    expect(countSentences('')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hardestKanjiScore
+// ---------------------------------------------------------------------------
+
+describe('hardestKanjiScore', () => {
+  it('returns 0 when no words', () => {
+    expect(hardestKanjiScore(undefined)).toBe(0);
+    expect(hardestKanjiScore([])).toBe(0);
+  });
+  it('returns max breakdown.jlptScore across words', () => {
+    expect(hardestKanjiScore([mkWord(15), mkWord(70), mkWord(30)])).toBe(70);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesSearch
+// ---------------------------------------------------------------------------
+
+describe('matchesSearch', () => {
+  const c = mkContent({
+    title: 'Spring Morning',
+    description: 'A short tale about spring.',
+    text: '春の朝です。',
+  });
+  it('empty query matches everything', () => {
+    expect(matchesSearch(c, '', new Set(['title']))).toBe(true);
+  });
+  it('searches title by default', () => {
+    expect(matchesSearch(c, 'spring', new Set(['title']))).toBe(true);
+    expect(matchesSearch(c, 'tale', new Set(['title']))).toBe(false);
+  });
+  it('searches description when scope includes description', () => {
+    expect(matchesSearch(c, 'tale', new Set(['description']))).toBe(true);
+  });
+  it('searches body when scope includes body', () => {
+    expect(matchesSearch(c, '春', new Set(['body']))).toBe(true);
+    expect(matchesSearch(c, '春', new Set(['title']))).toBe(false);
+  });
+  it('is case-insensitive', () => {
+    expect(matchesSearch(c, 'SPRING', new Set(['title']))).toBe(true);
+  });
+  it('with empty scope set, never matches a non-empty query', () => {
+    expect(matchesSearch(c, 'spring', new Set())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyContentFilters
+// ---------------------------------------------------------------------------
+
+describe('applyContentFilters', () => {
+  const items: Content[] = [
+    mkContent({ id: 'a', title: 'Alpha',   type: 'story',  level: 'N5',          tags: ['spring'],   text: '一文。二文。' }),
+    mkContent({ id: 'b', title: 'Beta',    type: 'music',  level: 'beginner',    tags: ['autumn'],   text: '一行\n二行\n三行' }),
+    mkContent({ id: 'c', title: 'Gamma',   type: 'video',  level: 'intermediate',tags: ['spring','newsy'], text: Array(20).fill('文。').join('') }),
+    mkContent({ id: 'd', title: 'Delta',   type: 'story',  level: 'N3',          tags: [],           text: Array(60).fill('文。').join('') }),
+  ];
+
+  const statuses: Record<string, ContentStatus> = {
+    a: mkStatus({ comprehension: 100, totalCount: 10 }),
+    b: mkStatus({ comprehension: 90,  totalCount: 10 }),
+    c: mkStatus({ comprehension: 50,  totalCount: 10 }),
+    d: mkStatus({ comprehension: 0,   totalCount: 0  }),
+  };
+
+  const statusFn = (id: string) => statuses[id];
+
+  it('default filters keep everything', () => {
+    const out = applyContentFilters(items, statusFn, DEFAULT_FILTERS);
+    expect(out.map(c => c.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('type filter', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, typeFilter: new Set(['story']) };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id)).toEqual(['a', 'd']);
+  });
+
+  it('level filter (case-insensitive, normalized)', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, levelFilter: new Set(['N5', 'beginner']) };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('tag filter (any-match)', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, tagFilter: new Set(['spring']) };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('length filter — short (<5 sentences)', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, lengthFilter: 'short' };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('length filter — long (>=30 sentences)', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, lengthFilter: 'long' };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id)).toEqual(['d']);
+  });
+
+  it('comprehension range filters by inclusive min/max', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, comprehensionRange: [85, 95] };
+    // a=100 out, b=90 in, c=50 out, d=unloaded (excluded when range != [0,100])
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id)).toEqual(['b']);
+  });
+
+  it('comprehension range [0,100] keeps unloaded items', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, comprehensionRange: [0, 100] };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('search applies across configured scopes', () => {
+    const f: ContentFilters = { ...DEFAULT_FILTERS, searchQuery: 'alpha', searchScope: new Set(['title']) };
+    expect(applyContentFilters(items, statusFn, f).map(c => c.id)).toEqual(['a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortContent
+// ---------------------------------------------------------------------------
+
+describe('sortContent', () => {
+  const items: Content[] = [
+    mkContent({ id: 'a', title: 'Cherry',   text: '短い。', dateAdded: '2025-01-01' }),
+    mkContent({ id: 'b', title: 'apple',    text: '一。二。三。', dateAdded: '2026-04-01' }),
+    mkContent({ id: 'c', title: 'Banana',   text: Array(10).fill('文。').join(''), dateAdded: '2025-06-15' }),
+  ];
+
+  const statuses: Record<string, ContentStatus> = {
+    a: mkStatus({ comprehension: 80, totalCount: 5, score: 50 }),
+    b: mkStatus({ comprehension: 100, totalCount: 3, score: 10 }),
+    c: mkStatus({ comprehension: 0,   totalCount: 0, score: 0  }),
+  };
+  const statusFn = (id: string) => statuses[id];
+
+  const vocab: Record<string, WordInfo[]> = {
+    a: [mkWord(50), mkWord(15)],
+    b: [mkWord(30)],
+    c: [],
+  };
+
+  const sortBy = (by: SortBy, dir: SortDir = 'asc') =>
+    sortContent(items, statusFn, vocab, by, dir).map(c => c.id);
+
+  it('title ascending (case-insensitive)', () => {
+    expect(sortBy('title', 'asc')).toEqual(['b', 'c', 'a']);
+  });
+
+  it('title descending', () => {
+    expect(sortBy('title', 'desc')).toEqual(['a', 'c', 'b']);
+  });
+
+  it('date — newest first when desc', () => {
+    expect(sortBy('date', 'desc')).toEqual(['b', 'c', 'a']);
+  });
+
+  it('comprehension descending', () => {
+    expect(sortBy('comprehension', 'desc')).toEqual(['b', 'a', 'c']);
+  });
+
+  it('length ascending uses sentence count', () => {
+    expect(sortBy('length', 'asc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('hardest-kanji uses max breakdown.jlptScore', () => {
+    // a=50, b=30, c=0 — ascending
+    expect(sortBy('hardest-kanji', 'asc')).toEqual(['c', 'b', 'a']);
+  });
+
+  it('difficulty sort keeps unloaded items at the bottom regardless of dir', () => {
+    // ascending: loaded ascending by score then unloaded
+    expect(sortBy('difficulty', 'asc')).toEqual(['b', 'a', 'c']);
+    // descending: loaded descending then unloaded
+    expect(sortBy('difficulty', 'desc')).toEqual(['a', 'b', 'c']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectTags
+// ---------------------------------------------------------------------------
+
+describe('collectTags', () => {
+  it('returns unique tags with counts, sorted by frequency desc then alpha', () => {
+    const items: Content[] = [
+      mkContent({ id: '1', tags: ['spring', 'children'] }),
+      mkContent({ id: '2', tags: ['spring'] }),
+      mkContent({ id: '3', tags: ['autumn', 'children'] }),
+      mkContent({ id: '4' }),
+    ];
+    const out = collectTags(items);
+    expect(out).toEqual([
+      { tag: 'children', count: 2 },
+      { tag: 'spring',   count: 2 },
+      { tag: 'autumn',   count: 1 },
+    ]);
+  });
+});

--- a/src/lib/contentFilters.ts
+++ b/src/lib/contentFilters.ts
@@ -1,0 +1,242 @@
+import type { Content } from '../data/content';
+import type { WordInfo } from '../types';
+
+export type SearchScope = 'title' | 'description' | 'body';
+export type LengthFilter = 'all' | 'short' | 'medium' | 'long';
+export type SortBy =
+  | 'difficulty'
+  | 'title'
+  | 'date'
+  | 'comprehension'
+  | 'length'
+  | 'hardest-kanji';
+export type SortDir = 'asc' | 'desc';
+
+export interface ContentStatus {
+  comprehension: number;
+  totalCount: number;
+  unknownCount: number;
+  score: number;
+}
+
+export interface ContentFilters {
+  searchQuery: string;
+  searchScope: Set<SearchScope>;
+  typeFilter: Set<string>;
+  levelFilter: Set<string>;       // normalized level keys, e.g. 'N5', 'beginner'
+  tagFilter: Set<string>;
+  lengthFilter: LengthFilter;
+  comprehensionRange: [number, number]; // inclusive 0..100; [0,100] disables the filter
+}
+
+export const DEFAULT_FILTERS: ContentFilters = {
+  searchQuery: '',
+  searchScope: new Set<SearchScope>(['title', 'description']),
+  typeFilter: new Set<string>(),
+  levelFilter: new Set<string>(),
+  tagFilter: new Set<string>(),
+  lengthFilter: 'all',
+  comprehensionRange: [0, 100],
+};
+
+// Length bands (sentence count). Tuned so a typical haiku or short song
+// lands in "short" and a multi-paragraph story lands in "medium" or "long".
+const LENGTH_BANDS: Record<Exclude<LengthFilter, 'all'>, [number, number]> = {
+  short: [0, 4],
+  medium: [5, 29],
+  long: [30, Number.POSITIVE_INFINITY],
+};
+
+const JLPT_RE = /\bN[1-5]\b/i;
+
+export function normalizeLevel(raw: string | undefined | null): string {
+  if (!raw) return 'unknown';
+  const trimmed = String(raw).trim();
+  if (!trimmed) return 'unknown';
+  const jlpt = trimmed.match(JLPT_RE);
+  if (jlpt) return jlpt[0].toUpperCase();
+  return trimmed.toLowerCase();
+}
+
+export function countSentences(text: string): number {
+  if (!text) return 0;
+  // Split on Japanese / western sentence terminators and newlines, then drop empties.
+  const parts = text
+    .split(/[。．！？!?\n\r]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+  return parts.length;
+}
+
+export function hardestKanjiScore(words: WordInfo[] | undefined): number {
+  if (!words || words.length === 0) return 0;
+  let max = 0;
+  for (const w of words) {
+    const s = w.breakdown?.jlptScore;
+    if (typeof s === 'number' && s > max) max = s;
+  }
+  return max;
+}
+
+export function matchesSearch(
+  c: Content,
+  rawQuery: string,
+  scope: Set<SearchScope>,
+): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+  if (scope.size === 0) return false;
+
+  const haystacks: string[] = [];
+  if (scope.has('title')) haystacks.push(c.title);
+  if (scope.has('description')) haystacks.push(c.description);
+  if (scope.has('body')) haystacks.push(c.text);
+
+  for (const h of haystacks) {
+    if (h && h.toLowerCase().includes(q)) return true;
+  }
+  return false;
+}
+
+function inLengthBand(text: string, band: LengthFilter): boolean {
+  if (band === 'all') return true;
+  const n = countSentences(text);
+  const [lo, hi] = LENGTH_BANDS[band];
+  return n >= lo && n <= hi;
+}
+
+function inComprehensionRange(
+  status: ContentStatus,
+  [min, max]: [number, number],
+): boolean {
+  // The default range [0,100] is a no-op; we want unloaded items (totalCount 0)
+  // to still show up. Only exclude unloaded items when the user has narrowed
+  // the range away from the defaults.
+  const isDefault = min === 0 && max === 100;
+  if (status.totalCount === 0) return isDefault;
+  return status.comprehension >= min && status.comprehension <= max;
+}
+
+export function applyContentFilters(
+  items: Content[],
+  statusFor: (id: string) => ContentStatus,
+  f: ContentFilters,
+): Content[] {
+  return items.filter(c => {
+    if (!matchesSearch(c, f.searchQuery, f.searchScope)) return false;
+    if (f.typeFilter.size > 0 && !f.typeFilter.has(c.type)) return false;
+    if (f.levelFilter.size > 0) {
+      const lvl = normalizeLevel(c.level);
+      const want = new Set(Array.from(f.levelFilter, normalizeLevel));
+      if (!want.has(lvl)) return false;
+    }
+    if (f.tagFilter.size > 0) {
+      const tags = c.tags ?? [];
+      const has = tags.some(t => f.tagFilter.has(t));
+      if (!has) return false;
+    }
+    if (!inLengthBand(c.text, f.lengthFilter)) return false;
+    if (!inComprehensionRange(statusFor(c.id), f.comprehensionRange)) return false;
+    return true;
+  });
+}
+
+export function sortContent(
+  items: Content[],
+  statusFor: (id: string) => ContentStatus,
+  vocab: Record<string, WordInfo[]>,
+  by: SortBy,
+  dir: SortDir,
+): Content[] {
+  const out = [...items];
+  const mult = dir === 'asc' ? 1 : -1;
+
+  if (by === 'title') {
+    out.sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()) * mult);
+    return out;
+  }
+
+  if (by === 'date') {
+    // Items without a dateAdded sort to the end regardless of dir.
+    out.sort((a, b) => {
+      const ad = a.dateAdded ?? '';
+      const bd = b.dateAdded ?? '';
+      if (!ad && !bd) return 0;
+      if (!ad) return 1;
+      if (!bd) return -1;
+      return ad.localeCompare(bd) * mult;
+    });
+    return out;
+  }
+
+  if (by === 'comprehension') {
+    out.sort((a, b) => {
+      const sa = statusFor(a.id);
+      const sb = statusFor(b.id);
+      // Unloaded items at the bottom regardless of dir.
+      if (sa.totalCount === 0 && sb.totalCount !== 0) return 1;
+      if (sa.totalCount !== 0 && sb.totalCount === 0) return -1;
+      return (sa.comprehension - sb.comprehension) * mult;
+    });
+    return out;
+  }
+
+  if (by === 'length') {
+    out.sort((a, b) => (countSentences(a.text) - countSentences(b.text)) * mult);
+    return out;
+  }
+
+  if (by === 'hardest-kanji') {
+    out.sort((a, b) => (hardestKanjiScore(vocab[a.id]) - hardestKanjiScore(vocab[b.id])) * mult);
+    return out;
+  }
+
+  // difficulty (the historical default): unloaded items always at the bottom,
+  // then sort by computed score in the requested direction.
+  out.sort((a, b) => {
+    const sa = statusFor(a.id);
+    const sb = statusFor(b.id);
+    if (sa.totalCount === 0 && sb.totalCount !== 0) return 1;
+    if (sa.totalCount !== 0 && sb.totalCount === 0) return -1;
+    return (sa.score - sb.score) * mult;
+  });
+  return out;
+}
+
+export interface TagCount {
+  tag: string;
+  count: number;
+}
+
+export function collectTags(items: Content[]): TagCount[] {
+  const counts = new Map<string, number>();
+  for (const c of items) {
+    for (const t of c.tags ?? []) {
+      if (!t) continue;
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => (b.count - a.count) || a.tag.localeCompare(b.tag));
+}
+
+export function collectLevels(items: Content[]): { level: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const c of items) {
+    const lvl = normalizeLevel(c.level);
+    if (lvl === 'unknown') continue;
+    counts.set(lvl, (counts.get(lvl) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([level, count]) => ({ level, count }))
+    .sort((a, b) => {
+      // Put JLPT levels first (N5 → N1), then alphabetical bands.
+      const aJ = JLPT_RE.test(a.level);
+      const bJ = JLPT_RE.test(b.level);
+      if (aJ && !bJ) return -1;
+      if (!aJ && bJ) return 1;
+      if (aJ && bJ) return b.level.localeCompare(a.level); // N5 before N1
+      return a.level.localeCompare(b.level);
+    });
+}

--- a/src/lib/storyLoader.ts
+++ b/src/lib/storyLoader.ts
@@ -154,6 +154,9 @@ export function loadStoriesFromDisk(): Content[] {
         description: metadata.description,
         text: text.trim(),
         imageUrl: metadata.imageUrl,
+        level: metadata.level,
+        tags: metadata.tags,
+        dateAdded: metadata.dateAdded,
       });
     } catch (error) {
       console.warn(`⚠️  Error loading story from ${folder}:`, error);
@@ -208,6 +211,9 @@ export function loadMusicFromDisk(): Content[] {
         text: text.trim(),
         mediaUrl: metadata.mediaUrl,
         imageUrl: metadata.imageUrl,
+        level: metadata.level,
+        tags: metadata.tags,
+        dateAdded: metadata.dateAdded,
       });
     } catch (error) {
       console.warn(`⚠️  Error loading music from ${folder}:`, error);
@@ -262,6 +268,9 @@ export function loadVideosFromDisk(): Content[] {
         text: text.trim(),
         mediaUrl: metadata.mediaUrl,
         imageUrl: metadata.imageUrl,
+        level: metadata.level,
+        tags: metadata.tags,
+        dateAdded: metadata.dateAdded,
       });
     } catch (error) {
       console.warn(`⚠️  Error loading video from ${folder}:`, error);

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
+  ArrowDown,
+  ArrowUp,
   BookOpen,
+  ChevronDown,
   ChevronRight,
   Loader2,
   Music,
@@ -10,27 +13,82 @@ import {
 } from 'lucide-react';
 import { Content } from '../data/content';
 import { WordInfo } from '../types';
+import type {
+  LengthFilter,
+  SearchScope,
+  SortBy,
+  SortDir,
+} from '../lib/contentFilters';
+
+const SORT_OPTIONS: { value: SortBy; label: string }[] = [
+  { value: 'difficulty', label: 'Difficulty' },
+  { value: 'hardest-kanji', label: 'Hardest kanji' },
+  { value: 'comprehension', label: 'Comprehension %' },
+  { value: 'length', label: 'Length' },
+  { value: 'title', label: 'Title' },
+  { value: 'date', label: 'Date added' },
+];
+
+const LENGTH_OPTIONS: { value: LengthFilter; label: string }[] = [
+  { value: 'all', label: 'Any length' },
+  { value: 'short', label: 'Short (≤4 sentences)' },
+  { value: 'medium', label: 'Medium (5–29)' },
+  { value: 'long', label: 'Long (30+)' },
+];
+
+const RANGE_PRESETS: { label: string; range: [number, number] }[] = [
+  { label: 'All', range: [0, 100] },
+  { label: 'Almost (85–95%)', range: [85, 95] },
+  { label: 'Almost (≥90%)', range: [90, 99] },
+  { label: 'Ready (100%)', range: [100, 100] },
+];
 
 function HomeView({
-  setSearchQuery,
   setDisplayCount,
+  searchQuery,
+  setSearchQuery,
+  searchScope,
+  toggleSearchScope,
+  typeFilter,
   toggleTypeFilter,
-  setComprehensionFilter,
-  setTypeFilter,
+  levelFilter,
+  toggleLevelFilter,
+  availableLevels,
+  tagFilter,
+  toggleTagFilter,
+  availableTags,
+  lengthFilter,
+  setLengthFilter,
+  comprehensionRange,
+  setComprehensionRange,
+  sortBy,
+  setSortBy,
+  sortDir,
+  setSortDir,
+  hasActiveFilters,
+  onClearFilters,
   setSelectedContent,
   getContentStatus,
   loadVocabForContent,
   comprehensionColor,
-
-  searchQuery,
-  typeFilter,
-  comprehensionFilter,
-  hasActiveFilters,
   visibleContent,
   loadingContent,
   displayCount,
   sortedContent,
 }: HomeViewProps) {
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+  const [showRange, setShowRange] = useState(false);
+
+  const TOP_TAGS = 8;
+  const visibleTags = tagsExpanded ? availableTags : availableTags.slice(0, TOP_TAGS);
+  const currentRangeLabel = (() => {
+    const preset = RANGE_PRESETS.find(
+      p => p.range[0] === comprehensionRange[0] && p.range[1] === comprehensionRange[1],
+    );
+    if (preset) return preset.label;
+    return `${comprehensionRange[0]}–${comprehensionRange[1]}%`;
+  })();
+
   return (
     <section>
       <div className="mb-6 flex items-baseline justify-between">
@@ -38,19 +96,19 @@ function HomeView({
           Recommended For You
         </h2>
         <p className="text-sm text-gray-500 uppercase tracking-widest font-medium">
-          Sorted by difficulty
+          {sortedContent.length} {sortedContent.length === 1 ? 'item' : 'items'}
         </p>
       </div>
 
-      {/* Search + filters (#12, #13) */}
+      {/* Search + filters */}
       <div className="mb-6 space-y-3">
+        {/* Row 1: search + scope + sort */}
         <div className="flex flex-wrap gap-2 items-center">
-          {/* Search */}
-          <div className="relative flex-1 min-w-[180px] max-w-xs">
+          <div className="relative flex-1 min-w-[200px] max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
             <input
               type="text"
-              placeholder="Search by title..."
+              placeholder="Search content..."
               value={searchQuery}
               onChange={(e) => {
                 setSearchQuery(e.target.value);
@@ -60,7 +118,51 @@ function HomeView({
             />
           </div>
 
-          {/* Type filter */}
+          {/* Search scope toggles */}
+          <div className="flex items-center gap-1 text-xs text-gray-500">
+            <span className="hidden sm:inline">in:</span>
+            {(['title', 'description', 'body'] as const).map((s) => (
+              <button
+                key={s}
+                onClick={() => toggleSearchScope(s)}
+                className={`px-2 py-1 rounded-md border text-xs font-medium transition-colors ${
+                  searchScope.has(s)
+                    ? 'bg-indigo-50 text-indigo-700 border-indigo-200'
+                    : 'bg-white text-gray-500 border-gray-200 hover:border-indigo-300'
+                }`}
+                title={s === 'body' ? 'Search Japanese text body' : `Search ${s}`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          {/* Sort dropdown */}
+          <div className="flex items-center gap-1 ml-auto">
+            <label className="text-xs text-gray-500 hidden sm:inline">Sort:</label>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as SortBy)}
+              className="text-xs font-semibold px-3 py-2 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            >
+              {SORT_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <button
+              onClick={() => setSortDir(sortDir === 'asc' ? 'desc' : 'asc')}
+              className="p-2 rounded-xl border border-gray-200 bg-white hover:border-indigo-300"
+              title={sortDir === 'asc' ? 'Ascending — click to reverse' : 'Descending — click to reverse'}
+            >
+              {sortDir === 'asc'
+                ? <ArrowUp className="w-3.5 h-3.5 text-gray-600" />
+                : <ArrowDown className="w-3.5 h-3.5 text-gray-600" />}
+            </button>
+          </div>
+        </div>
+
+        {/* Row 2: type, length, comprehension */}
+        <div className="flex flex-wrap gap-2 items-center">
           {(['story', 'video', 'music'] as const).map((type) => (
             <button
               key={type}
@@ -78,50 +180,167 @@ function HomeView({
             </button>
           ))}
 
-          {/* Comprehension filter (#13) */}
-          <div className="flex rounded-xl border border-gray-200 overflow-hidden bg-white text-xs font-semibold">
-            {(['all', 'almost', 'ready'] as const).map((f, i) => (
-              <button
-                key={f}
-                onClick={() => {
-                  setComprehensionFilter(f);
-                  setDisplayCount(12);
-                }}
-                className={`px-3 py-2 transition-colors ${i > 0 ? 'border-l border-gray-200' : ''} ${
-                  comprehensionFilter === f
-                    ? 'bg-indigo-600 text-white'
-                    : 'text-gray-600 hover:bg-gray-50'
-                }`}
-              >
-                {f === 'all'
-                  ? 'All'
-                  : f === 'almost'
-                    ? 'Almost There ≥90%'
-                    : 'Ready ✓'}
-              </button>
+          <select
+            value={lengthFilter}
+            onChange={(e) => {
+              setLengthFilter(e.target.value as LengthFilter);
+              setDisplayCount(12);
+            }}
+            className="text-xs font-semibold px-3 py-2 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          >
+            {LENGTH_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
             ))}
+          </select>
+
+          {/* Comprehension range — popover-style trigger */}
+          <div className="relative">
+            <button
+              onClick={() => setShowRange(v => !v)}
+              className={`flex items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-xl border transition-colors ${
+                comprehensionRange[0] !== 0 || comprehensionRange[1] !== 100
+                  ? 'bg-indigo-600 text-white border-indigo-600'
+                  : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+              }`}
+            >
+              Comprehension: {currentRangeLabel}
+              <ChevronDown className="w-3.5 h-3.5" />
+            </button>
+            {showRange && (
+              <div className="absolute z-20 mt-2 w-72 bg-white border border-gray-200 rounded-2xl shadow-lg p-4 space-y-3">
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wider">Presets</p>
+                  <div className="flex flex-wrap gap-1">
+                    {RANGE_PRESETS.map(p => {
+                      const active = p.range[0] === comprehensionRange[0] && p.range[1] === comprehensionRange[1];
+                      return (
+                        <button
+                          key={p.label}
+                          onClick={() => {
+                            setComprehensionRange(p.range);
+                            setDisplayCount(12);
+                          }}
+                          className={`px-2 py-1 rounded-md text-xs font-medium border transition-colors ${
+                            active
+                              ? 'bg-indigo-50 text-indigo-700 border-indigo-200'
+                              : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                          }`}
+                        >
+                          {p.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wider">
+                    Custom range: {comprehensionRange[0]}–{comprehensionRange[1]}%
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={0}
+                      max={100}
+                      value={comprehensionRange[0]}
+                      onChange={(e) => {
+                        const v = Math.max(0, Math.min(100, Number(e.target.value) || 0));
+                        setComprehensionRange([Math.min(v, comprehensionRange[1]), comprehensionRange[1]]);
+                        setDisplayCount(12);
+                      }}
+                      className="w-20 px-2 py-1 text-sm rounded-md border border-gray-200"
+                    />
+                    <span className="text-gray-400">–</span>
+                    <input
+                      type="number"
+                      min={0}
+                      max={100}
+                      value={comprehensionRange[1]}
+                      onChange={(e) => {
+                        const v = Math.max(0, Math.min(100, Number(e.target.value) || 100));
+                        setComprehensionRange([comprehensionRange[0], Math.max(v, comprehensionRange[0])]);
+                        setDisplayCount(12);
+                      }}
+                      className="w-20 px-2 py-1 text-sm rounded-md border border-gray-200"
+                    />
+                  </div>
+                  <p className="text-[11px] text-gray-400 mt-2">
+                    Items without analysed vocab only appear when the range is All (0–100).
+                  </p>
+                </div>
+                <div className="flex justify-end">
+                  <button
+                    onClick={() => setShowRange(false)}
+                    className="text-xs text-gray-500 hover:text-gray-900"
+                  >
+                    Close
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
-          {/* Clear filters */}
           {hasActiveFilters && (
             <button
-              onClick={() => {
-                setSearchQuery('');
-                setTypeFilter(new Set());
-                setComprehensionFilter('all');
-                setDisplayCount(12);
-              }}
-              className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700 transition-colors px-2 py-2"
+              onClick={onClearFilters}
+              className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700 transition-colors px-2 py-2 ml-auto"
             >
               <X className="w-3.5 h-3.5" /> Clear
             </button>
           )}
         </div>
 
-        {/* "Almost There" explanation banner (#13) */}
-        {comprehensionFilter === 'almost' && (
+        {/* Row 3: level chips (only when there are any) */}
+        {availableLevels.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 items-center">
+            <span className="text-xs text-gray-500 mr-1">Level:</span>
+            {availableLevels.map(({ level, count }) => (
+              <button
+                key={level}
+                onClick={() => toggleLevelFilter(level)}
+                className={`px-2.5 py-1 text-xs font-medium rounded-md border transition-colors ${
+                  levelFilter.has(level)
+                    ? 'bg-indigo-600 text-white border-indigo-600'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                }`}
+              >
+                {level} <span className="opacity-60">({count})</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Row 4: tag chips */}
+        {availableTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 items-center">
+            <span className="text-xs text-gray-500 mr-1">Tags:</span>
+            {visibleTags.map(({ tag, count }) => (
+              <button
+                key={tag}
+                onClick={() => toggleTagFilter(tag)}
+                className={`px-2.5 py-1 text-xs font-medium rounded-md border transition-colors ${
+                  tagFilter.has(tag)
+                    ? 'bg-indigo-600 text-white border-indigo-600'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                }`}
+              >
+                {tag} <span className="opacity-60">({count})</span>
+              </button>
+            ))}
+            {availableTags.length > TOP_TAGS && (
+              <button
+                onClick={() => setTagsExpanded(v => !v)}
+                className="text-xs text-indigo-600 hover:text-indigo-800 px-2 py-1"
+              >
+                {tagsExpanded ? 'Show fewer' : `+${availableTags.length - TOP_TAGS} more`}
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* "Almost There" explanation banner (when range matches the classic almost preset) */}
+        {comprehensionRange[0] >= 85 && comprehensionRange[1] < 100 && (
           <div className="bg-green-50 border border-green-100 rounded-2xl px-4 py-3 text-sm text-green-800">
-            <strong>i+1 sweet spot</strong> — content where you know ≥90% of
+            <strong>i+1 sweet spot</strong> — content where you know {comprehensionRange[0]}–{comprehensionRange[1]}% of
             words. Challenging enough to encounter new vocabulary, easy enough
             to enjoy reading.
           </div>
@@ -133,6 +352,8 @@ function HomeView({
           const status = getContentStatus(content.id);
           const isLoading =
             loadingContent[content.id] || status.totalCount === 0;
+          const showUnknownChips =
+            comprehensionRange[0] >= 85 && comprehensionRange[1] < 100;
 
           return (
             <div
@@ -177,7 +398,6 @@ function HomeView({
                     {content.type}
                   </span>
                 </div>
-                {/* Comprehension badge (#11) */}
                 {!isLoading && status.totalCount > 0 && (
                   <div
                     className={`absolute top-4 right-4 px-2.5 py-1 rounded-full text-xs font-bold border ${comprehensionColor(status.comprehension)}`}
@@ -191,16 +411,33 @@ function HomeView({
 
               <div className="p-5 flex flex-col flex-grow">
                 <h3 className="font-semibold text-lg mb-2">{content.title}</h3>
+                {(content.level || (content.tags && content.tags.length > 0)) && (
+                  <div className="flex flex-wrap gap-1 mb-2">
+                    {content.level && (
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded bg-indigo-50 text-indigo-700 border border-indigo-100">
+                        {content.level}
+                      </span>
+                    )}
+                    {content.tags?.slice(0, 3).map(t => (
+                      <span
+                        key={t}
+                        className="px-1.5 py-0.5 text-[10px] rounded bg-gray-50 text-gray-600 border border-gray-200"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
                 <p className="text-sm text-gray-500 line-clamp-2 mb-4 flex-grow">
                   {content.description}
                 </p>
 
-                {/* In "Almost There" mode, show unknown word chips (#13) */}
-                {comprehensionFilter === 'almost' &&
+                {showUnknownChips &&
                   !isLoading &&
-                  status.unknownCount > 0 && (
+                  'unknownWords' in status &&
+                  (status as { unknownWords: WordInfo[] }).unknownWords.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-3">
-                      {status.unknownWords.slice(0, 6).map((w) => (
+                      {(status as { unknownWords: WordInfo[] }).unknownWords.slice(0, 6).map((w) => (
                         <span
                           key={w.word}
                           className="px-2 py-0.5 bg-amber-50 border border-amber-200 text-amber-800 rounded-md text-xs font-medium"
@@ -253,11 +490,7 @@ function HomeView({
               No content matches your filters.
             </p>
             <button
-              onClick={() => {
-                setSearchQuery('');
-                setTypeFilter(new Set());
-                setComprehensionFilter('all');
-              }}
+              onClick={onClearFilters}
               className="mt-3 text-sm text-indigo-500 hover:text-indigo-700 underline"
             >
               Clear filters
@@ -281,31 +514,52 @@ function HomeView({
 }
 
 type HomeViewProps = {
-  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
   setDisplayCount: React.Dispatch<React.SetStateAction<number>>;
-  setComprehensionFilter: React.Dispatch<React.SetStateAction<'all' | 'almost' | 'ready'>>;
-  setTypeFilter: React.Dispatch<React.SetStateAction<Set<string>>>;
+
+  searchQuery: string;
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+
+  searchScope: Set<SearchScope>;
+  toggleSearchScope: (scope: SearchScope) => void;
+
+  typeFilter: Set<string>;
+  toggleTypeFilter: (type: 'story' | 'video' | 'music') => void;
+
+  levelFilter: Set<string>;
+  toggleLevelFilter: (level: string) => void;
+  availableLevels: { level: string; count: number }[];
+
+  tagFilter: Set<string>;
+  toggleTagFilter: (tag: string) => void;
+  availableTags: { tag: string; count: number }[];
+
+  lengthFilter: LengthFilter;
+  setLengthFilter: React.Dispatch<React.SetStateAction<LengthFilter>>;
+
+  comprehensionRange: [number, number];
+  setComprehensionRange: React.Dispatch<React.SetStateAction<[number, number]>>;
+
+  sortBy: SortBy;
+  setSortBy: React.Dispatch<React.SetStateAction<SortBy>>;
+  sortDir: SortDir;
+  setSortDir: React.Dispatch<React.SetStateAction<SortDir>>;
+
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+
   loadVocabForContent: (content: Content) => void;
   setSelectedContent: React.Dispatch<React.SetStateAction<Content | null>>;
-  
-
-  toggleTypeFilter: (type: 'story' | 'video' | 'music') => void;
   getContentStatus: (contentId: string) => {
-    difficulty: number;
-    totalUnknownScore: number;
+    difficulty?: number;
+    totalUnknownScore?: number;
     unknownCount: number;
     totalCount: number;
     score: number;
-    unknownWords: WordInfo[];
+    unknownWords?: WordInfo[];
     comprehension: number;
   };
   comprehensionColor: (comprehension: number) => string;
 
-
-  searchQuery: string;
-  typeFilter: Set<string>;
-  comprehensionFilter: 'all' | 'almost' | 'ready';
-  hasActiveFilters: boolean;
   visibleContent: Content[];
   loadingContent: Record<string, boolean>;
   displayCount: number;


### PR DESCRIPTION
## Summary
This PR significantly enhances the content discovery experience on the home view by introducing a flexible filtering and sorting system. Users can now search across multiple scopes (title, description, body text), filter by content type, difficulty level, tags, and length, adjust comprehension ranges with presets, and sort by multiple criteria. All filter and sort preferences are persisted to localStorage.

## Key Changes

### New Filtering & Sorting Infrastructure
- **`src/lib/contentFilters.ts`** (new): Core filtering and sorting logic
  - `ContentFilters` interface with support for search scope, type, level, tag, length, and comprehension range filters
  - `applyContentFilters()` function to filter content based on all criteria
  - `sortContent()` function supporting 6 sort modes: difficulty, title, date, comprehension, length, and hardest-kanji
  - Helper functions: `normalizeLevel()`, `countSentences()`, `hardestKanjiScore()`, `matchesSearch()`
  - `collectTags()` and `collectLevels()` to extract available filter options from content
  - Comprehensive test suite (`src/lib/contentFilters.test.ts`) with 30+ test cases

### Enhanced Home View UI
- **`src/views/HomeView.tsx`** (modified): Redesigned filter panel with 4 rows
  - **Row 1**: Search input + search scope toggles (title/description/body) + sort dropdown + sort direction button
  - **Row 2**: Type filter chips (story/video/music) + length dropdown + comprehension range popover
  - **Row 3**: Level filter chips (dynamically shown if available)
  - **Row 4**: Tag filter chips with "show more" toggle (displays top 8 by default)
  - Comprehension range popover with 4 presets (All, Almost 85–95%, Almost ≥90%, Ready 100%) and custom range inputs
  - Content cards now display level and tag badges
  - Item count display in header
  - Clear filters button (only shown when filters are active)

### State Management & Persistence
- **`src/App.tsx`** (modified): Refactored filter state management
  - Replaced simple `comprehensionFilter` with granular `comprehensionRange` state
  - Added `searchScope`, `levelFilter`, `tagFilter`, `lengthFilter`, `sortBy`, `sortDir` state
  - Implemented localStorage persistence under `HOME_FILTERS_KEY` to survive page reloads
  - New helper functions: `toggleLevelFilter()`, `toggleTagFilter()`, `toggleSearchScope()`, `clearAllFilters()`
  - Updated `hasActiveFilters` logic to account for all new filter types

### Data Model Updates
- **`src/data/content.ts`** (modified): Extended `Content` interface
  - Added optional `level` field (JLPT level or difficulty band)
  - Added optional `tags` array
  - Added optional `dateAdded` field for sorting
- **`src/lib/storyLoader.ts`** (modified): Updated to extract and populate level, tags, and dateAdded from metadata

## Notable Implementation Details

- **Search scope**: Defaults to title + description; users can toggle to include body text. At least one scope must always be active.
- **Comprehension range**: Default [0, 100] is a no-op that includes unloaded items. Narrowing the range excludes items without analyzed vocabulary.
- **Length bands**: Short (≤4 sentences), Medium (5–29), Long (30+) — tuned for typical haiku/songs vs. multi-paragraph stories.
- **Level normalization**: Case-insensitive matching with support for JLPT (N1–N5) and difficulty bands (beginner, intermediate, advanced).
- **Difficulty sort**: Unloaded items always appear at the bottom regardless of sort direction.
- **Tag/Level display**: Limited to top 8 tags by default with expandable "show more" button; level chips only shown if any content has a level.
- **localStorage format**: Filters are serialized as plain objects with Sets converted to arrays for JSON compatibility.

https://claude.ai/code/session_01K3UxUcCY8p2H939UAq2mXg