### PR TITLE
Add Kitaguchi EP5 story and fix jmdict worker lock issue

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1018,9 +1018,12 @@ async function startServer() {
 
       const workerData: WorkerInitData = {
         jmdictPath: path.join(__dirname, 'jmdict-db'),
-        jmdictFile: fs.existsSync(path.join(__dirname, 'jmdict-all-3.6.2.json'))
-          ? path.join(__dirname, 'jmdict-all-3.6.2.json')
-          : null,
+        // Do not pass jmdictFile to the worker. jmdict-wrapper uses LevelDB
+        // (classic-level) which holds an exclusive lock on the jmdict-db directory.
+        // The main thread already holds that lock; a second open from the worker
+        // thread fails with "Database is not open". The worker falls back to
+        // Jisho API which is correct for background extraction.
+        jmdictFile: null,
         jmnedictFile,
         // Seed the worker's kana cache with everything already persisted in this
         // process so the worker avoids redundant Jisho API round-trips.

--- a/src/stories/kitaguchi-ep5-ruri/metadata.json
+++ b/src/stories/kitaguchi-ep5-ruri/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "kitaguchi-ep5-ruri",
+  "title": "余白の使い方",
+  "type": "story",
+  "description": "画家の桐嶋瑠璃は、ギャラリーに企画書を却下されたあと、西荻窪の北口の縁石に腰を降ろし、自分のドローイングを広げながら、余白とは何かを静かに問い直す。",
+  "level": "n1",
+  "tags": ["series", "literary", "urban", "tokyo", "multiple-pov", "n1"],
+  "seriesId": "eki-no-kitaguchi-de",
+  "episodeNumber": 5,
+  "dateAdded": "2026-05-12"
+}


### PR DESCRIPTION
## Summary

This PR adds a new story to the collection and fixes a critical database locking issue in the worker thread initialization.

## Changes

- **New story**: Added "余白の使い方" (The Use of Whitespace) as episode 5 of the "eki-no-kitaguchi-de" series
  - N1 level literary story set in Tokyo
  - Metadata includes series tracking and episode numbering

- **Worker thread fix**: Resolved exclusive lock contention on the jmdict LevelDB directory
  - The main thread holds an exclusive lock on `jmdict-db` via `jmdict-wrapper`
  - Removed `jmdictFile` path from worker initialization to prevent a second open attempt
  - Worker now correctly falls back to Jisho API for background dictionary extraction
  - Added explanatory comments documenting the LevelDB locking behavior

## Implementation Details

The jmdict-wrapper uses classic-level (LevelDB), which enforces exclusive locks on the database directory. When the worker thread attempted to open the same database, it would fail with "Database is not open". By passing `null` for `jmdictFile` to the worker, it gracefully falls back to the Jisho API, which is appropriate for background extraction tasks and avoids the locking conflict entirely.

https://claude.ai/code/session_01UShEKFTfTcwcxbqe2WNN9e