### PR TITLE
Add modal editing UI for word details on WordDetailPage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,13 +371,22 @@ export default function App() {
 
   if (selectedWord) {
     return (
-      <WordDetailPage
-        word={selectedWord}
-        onBack={navigateBack}
-        allWords={Object.values(contentVocab).flat() as WordInfo[]}
-        onNavigateWord={navigateToWord}
-        onEdit={(wordInfo) => setEditingWord(wordInfo)}
-      />
+      <>
+        <WordDetailPage
+          word={selectedWord}
+          onBack={navigateBack}
+          allWords={Object.values(contentVocab).flat() as WordInfo[]}
+          onNavigateWord={navigateToWord}
+          onEdit={(wordInfo) => setEditingWord(wordInfo)}
+        />
+        {editingWord && (
+          <WordDetailModal
+            w={editingWord}
+            onClose={() => setEditingWord(null)}
+            onSave={(wordStr, updatedMap) => updateWord(wordStr, updatedMap)}
+          />
+        )}
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary
Wraps the `WordDetailPage` component in a fragment and conditionally renders a `WordDetailModal` when a word is being edited, allowing users to edit vocabulary entries without navigating away from the word detail view.

## Changes
- Wrapped `WordDetailPage` return in a React fragment (`<>...</>`)
- Added conditional rendering of `WordDetailModal` component that appears when `editingWord` state is set
- Modal receives the editing word, close handler, and save handler that updates the word via `updateWord()`
- Maintains existing `onEdit` callback that sets `editingWord` state when edit is triggered from the detail page

## Implementation Details
The modal is rendered as a sibling to `WordDetailPage` within the same fragment, allowing both the detail view and edit modal to coexist. The modal's `onClose` handler clears the `editingWord` state, and `onSave` delegates to the existing `updateWord()` function to persist changes to the vocabulary map.

https://claude.ai/code/session_01PGuFi5KzwQEFdoPRs1vPC7