### PR TITLE
Fix JMnedict fallback for kanji names & refresh stale cache entries

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -186,7 +186,7 @@ const dictionaryReady = (async () => {
 
 const refreshingContent = new Set<string>();
 const lastRefreshTime = new Map<string, number>();
-const REFRESH_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes per content ID
+const REFRESH_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes per content ID
 
 async function refreshUnknownMeanings(contentId: string, words: WordInfo[]): Promise<void> {
   if (!wordResolver) return;

--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ import { loadStoriesFromDisk, loadMusicFromDisk, loadVideosFromDisk } from "./sr
 import { initDatabase, WordsCache, JishoCache, ContentWordsStore, saveDatabase } from "./src/lib/database.js";
 import { isPunctuation, isSingleKana, looksLikePartialStem } from "./src/lib/extraction-helpers.js";
 import type { WorkerInitData, WorkerOutMessage } from "./src/lib/extraction-worker.js";
+import type { WordInfo } from "./src/types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -173,6 +174,72 @@ const dictionaryReady = (async () => {
 })();
 
 
+
+// ---------------------------------------------------------------------------
+// Background re-lookup for "Unknown meaning" cache entries
+//
+// Words extracted before the dictionary was fully initialised (or before the
+// JMnedict fallback fix) land in content_words with meaning="Unknown meaning".
+// On the next request that serves those words we fire a background re-resolution
+// so subsequent requests return real definitions without blocking the first one.
+// ---------------------------------------------------------------------------
+
+const refreshingContent = new Set<string>();
+const lastRefreshTime = new Map<string, number>();
+const REFRESH_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes per content ID
+
+async function refreshUnknownMeanings(contentId: string, words: WordInfo[]): Promise<void> {
+  if (!wordResolver) return;
+
+  const unknownWords = words.filter(
+    w => w.meaning === 'Unknown meaning' && !isPunctuation(w.word)
+  );
+  if (unknownWords.length === 0) return;
+
+  console.log(`[Cache] Refreshing ${unknownWords.length} unknown-meaning words for ${contentId}`);
+  const wordMap = new Map(words.map(w => [w.word, { ...w }]));
+  let updated = false;
+
+  for (const w of unknownWords) {
+    try {
+      const resolution = await wordResolver.resolve(w.word, w.word);
+      if (resolution.meaning !== 'Unknown meaning') {
+        wordMap.set(w.word, {
+          ...wordMap.get(w.word)!,
+          reading: resolution.reading,
+          meaning: resolution.meaning,
+          ...(resolution.meanings ? { meanings: resolution.meanings } : {}),
+          jlpt: resolution.jlpt,
+          joyo: resolution.joyo,
+          score: resolution.score,
+          breakdown: resolution.breakdown,
+        });
+        updated = true;
+      }
+    } catch (e: any) {
+      console.error(`[Cache] Refresh failed for "${w.word}":`, e.message);
+    }
+  }
+
+  if (updated) {
+    await contentWordsStore.setContentWords(contentId, [...wordMap.values()]);
+    await saveDatabase();
+    console.log(`[Cache] Updated unknown-meaning entries for ${contentId}`);
+  }
+}
+
+function scheduleRefreshIfNeeded(contentId: string, words: WordInfo[]): void {
+  if (refreshingContent.has(contentId)) return;
+  const now = Date.now();
+  if (now - (lastRefreshTime.get(contentId) ?? 0) < REFRESH_COOLDOWN_MS) return;
+  if (!words.some(w => w.meaning === 'Unknown meaning' && !isPunctuation(w.word))) return;
+
+  refreshingContent.add(contentId);
+  lastRefreshTime.set(contentId, now);
+  refreshUnknownMeanings(contentId, words).finally(() => {
+    refreshingContent.delete(contentId);
+  });
+}
 
 async function processText(text: string, kanaLookupCache?: Map<string, any>) {
   if (!tokenizer) throw new Error("Tokenizer not ready");
@@ -840,7 +907,19 @@ async function startServer() {
 
   app.get("/api/content/words", (req, res) => {
     try {
-      res.json(contentWordsStore.getAllContentWords());
+      const allWords = contentWordsStore.getAllContentWords();
+      res.json(allWords);
+
+      // Schedule background refresh for content IDs with unknown-meaning words,
+      // limited to 3 at a time so we don't flood the event loop on the bulk call.
+      let scheduled = 0;
+      for (const [contentId, words] of Object.entries(allWords)) {
+        if (scheduled >= 3) break;
+        if (!refreshingContent.has(contentId)) {
+          scheduleRefreshIfNeeded(contentId, words);
+          if (refreshingContent.has(contentId)) scheduled++;
+        }
+      }
     } catch (e: any) {
       console.error('[API Error] /api/content/words failed:', e.message);
       res.status(500).json({ error: e.message });
@@ -850,7 +929,9 @@ async function startServer() {
   app.get("/api/content/:contentId/words", (req, res) => {
     try {
       const { contentId } = req.params;
-      res.json(contentWordsStore.getContentWords(contentId));
+      const words = contentWordsStore.getContentWords(contentId);
+      res.json(words);
+      scheduleRefreshIfNeeded(contentId, words);
     } catch (e: any) {
       console.error(`[API Error] /api/content/${req.params.contentId}/words failed:`, e.message);
       res.status(500).json({ error: e.message });

--- a/src/lib/dictionary.test.ts
+++ b/src/lib/dictionary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEnglishGlosses, getSenseCommonness } from './dictionary';
+import { getEnglishGlosses, getSenseCommonness, DictionaryManager } from './dictionary';
 import { getMorphemeDefinition } from './morphemeDefinitions';
 
 // ---------------------------------------------------------------------------
@@ -324,5 +324,47 @@ describe('mixed kanji+kana sense ordering – real-world cases (#191)', () => {
   it('ない has a morpheme definition (not undefined)', () => {
     expect(getMorphemeDefinition('ない')).toBeDefined();
     expect(getMorphemeDefinition('ない')).toMatch(/negat/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DictionaryManager – JMnedict fallback for kanji-containing names
+//
+// The previous DictionaryManager.lookup() only tried the JMnedict fallback for
+// pure-hiragana words. Kanji-written names like 和彦 or 山城屋 would fail the
+// primary lookup and then skip JMnedict entirely, always returning null (which
+// became "Unknown meaning" in WordResolver).  The fix removes the isPureHiragana
+// guard so JMnedict is tried for any word the primary dictionary misses.
+// ---------------------------------------------------------------------------
+
+describe('DictionaryManager – JMnedict fallback', () => {
+  it('tries JMnedict for kanji-containing words when primary returns null', async () => {
+    const manager = new DictionaryManager();
+
+    // Inject mock dictionaries directly (TypeScript cast to bypass private fields).
+    const primaryMock = { lookup: async (_word: string) => null };
+    const jmnedictMock = {
+      lookup: async (word: string) =>
+        word === '和彦'
+          ? { meaning: 'Japanese male given name', reading: 'かずひこ', meanings: ['Japanese male given name'] }
+          : null,
+    };
+    (manager as any).primary = primaryMock;
+    (manager as any).fallback1 = jmnedictMock;
+
+    const result = await manager.lookup('和彦');
+    expect(result).not.toBeNull();
+    expect(result?.meaning).toBe('Japanese male given name');
+  });
+
+  it('still returns null when both primary and JMnedict miss the word', async () => {
+    const manager = new DictionaryManager();
+    const primaryMock = { lookup: async (_word: string) => null };
+    const jmnedictMock = { lookup: async (_word: string) => null };
+    (manager as any).primary = primaryMock;
+    (manager as any).fallback1 = jmnedictMock;
+
+    const result = await manager.lookup('和彦');
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -564,10 +564,10 @@ export class DictionaryManager {
     const result = await this.primary.lookup(word);
     if (result) return result;
 
-    // For pure hiragana words, try JMnedict next (proper nouns)
-    // This is after primary cache, so frequent hiragana hits the cache
-    const isPureHiragana = /^[ぁ-ん]+$/.test(word);
-    if (isPureHiragana && this.fallback1) {
+    // Try JMnedict for names and proper nouns — these can be hiragana, katakana,
+    // or kanji-written (e.g. 和彦, 山城屋). The previous guard limited this to
+    // pure-hiragana only, causing kanji-written names to always return null here.
+    if (this.fallback1) {
       const jmnedictResult = await this.fallback1.lookup(word);
       if (jmnedictResult) return jmnedictResult;
     }

--- a/src/lib/extraction-helpers.test.ts
+++ b/src/lib/extraction-helpers.test.ts
@@ -9,6 +9,18 @@ describe('extraction helpers', () => {
       }
     });
 
+    it('returns true for full-width punctuation that slipped through the old regex', () => {
+      // These were previously extracted as vocabulary items with "Unknown meaning"
+      // because the old regex only covered a limited allowlist of symbols.
+      expect(isPunctuation('：')).toBe(true);   // full-width colon
+      expect(isPunctuation('…')).toBe(true);    // horizontal ellipsis
+      expect(isPunctuation('［')).toBe(true);   // full-width left bracket
+      expect(isPunctuation('］')).toBe(true);   // full-width right bracket
+      expect(isPunctuation('｜')).toBe(true);   // full-width vertical bar
+      expect(isPunctuation('＃')).toBe(true);   // full-width hash
+      expect(isPunctuation('②')).toBe(true);   // circled digit
+    });
+
     it('returns true for ASCII alphanumerics and whitespace', () => {
       expect(isPunctuation('a')).toBe(true);
       expect(isPunctuation('Z')).toBe(true);
@@ -24,6 +36,13 @@ describe('extraction helpers', () => {
     it('returns false for hiragana words', () => {
       expect(isPunctuation('ねこ')).toBe(false);
       expect(isPunctuation('は')).toBe(false);
+    });
+
+    it('returns false for katakana loanwords', () => {
+      // Katakana words must NOT be filtered as punctuation; they are real vocabulary.
+      expect(isPunctuation('ピクニック')).toBe(false);
+      expect(isPunctuation('クレヨン')).toBe(false);
+      expect(isPunctuation('ラビット')).toBe(false);
     });
   });
 

--- a/src/lib/extraction-helpers.ts
+++ b/src/lib/extraction-helpers.ts
@@ -10,9 +10,16 @@ export const PARTICLES = new Set([
   'は', 'が', 'を', 'に', 'へ', 'と', 'で', 'も', 'か', 'の', 'て', 'な', 'だ',
 ]);
 
-/** Returns true for characters that should be skipped entirely during extraction. */
+/**
+ * Returns true for tokens that should be skipped entirely during extraction.
+ *
+ * Uses a negative test: a token is "punctuation" if it contains NO Japanese
+ * vocabulary characters (kanji, hiragana, katakana). This handles full-width
+ * punctuation (：, …, ［, ＃, ②, etc.) without maintaining an ever-growing
+ * allowlist, and correctly passes katakana loanwords through to the dictionary.
+ */
 export function isPunctuation(s: string): boolean {
-  return /[、。！？・「」『』（）()[\]a-zA-Z0-9\s]/.test(s);
+  return !/[ぁ-ん゛゜ァ-ヴー一-鿿々〆〇]/.test(s);
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes two related issues with vocabulary caching and dictionary lookups:

1. **JMnedict fallback now works for kanji-written names** — Previously, the `DictionaryManager` only tried the JMnedict fallback for pure-hiragana words, causing kanji-written names (e.g. 和彦, 山城屋) to always return null and be cached as "Unknown meaning". The fix removes the hiragana-only guard.

2. **Background refresh of stale "Unknown meaning" entries** — Words extracted before the dictionary was fully initialized (or before the JMnedict fix) are now refreshed in the background on subsequent requests, so users see real definitions without blocking the initial response.

3. **Improved punctuation detection** — The `isPunctuation()` helper now uses a negative test (checking for the *presence* of Japanese characters) instead of an allowlist, which correctly handles full-width punctuation (：, …, ［, ＃, ②, etc.) and prevents katakana loanwords from being filtered out.

## Key Changes

- **`src/lib/dictionary.ts`**: Removed the `isPureHiragana` guard in `DictionaryManager.lookup()` so JMnedict is tried for any word the primary dictionary misses, regardless of script type.

- **`src/lib/extraction-helpers.ts`**: Rewrote `isPunctuation()` to use a negative regex test (`!/[ぁ-ん゛゜ァ-ヴー一-鿿々〆〇]/`) instead of an allowlist. This handles full-width punctuation without maintenance and correctly passes katakana through.

- **`server.ts`**: 
  - Added `refreshUnknownMeanings()` and `scheduleRefreshIfNeeded()` functions to detect and re-resolve words with "Unknown meaning" in the background.
  - Added cooldown tracking (`lastRefreshTime`, `REFRESH_COOLDOWN_MS = 30 min`) to avoid hammering the same content repeatedly.
  - Modified `/api/content/words` and `/api/content/:contentId/words` endpoints to schedule background refreshes after responding (limited to 3 concurrent refreshes to avoid event loop flooding).
  - Added import for `WordInfo` type.

- **`src/lib/dictionary.test.ts`**: Added test suite for `DictionaryManager` JMnedict fallback behavior, covering both successful kanji-name lookups and null cases.

- **`src/lib/extraction-helpers.test.ts`**: Added tests for full-width punctuation handling and katakana loanword preservation.

## Implementation Details

- Background refresh is non-blocking: the API response is sent immediately, then `refreshUnknownMeanings()` runs asynchronously.
- A 30-minute cooldown per content ID prevents repeated refresh attempts for the same content.
- The refresh only updates words that still have "Unknown meaning" and successfully resolve to something better.
- Refreshed entries are persisted to the SQLite cache via `contentWordsStore.setContentWords()` and `saveDatabase()`.

https://claude.ai/code/session_019wUuDD81ghukH6Jkqr49nq